### PR TITLE
feat: CDC 2.4.x multi-table support, 3 JSON output formats, WAL reliability

### DIFF
--- a/flink-connector-gaussdb-cdc-1.17/README.md
+++ b/flink-connector-gaussdb-cdc-1.17/README.md
@@ -350,42 +350,11 @@ CREATE TABLE student (
 
 | 参数 | 必填 | 默认值 | 说明 |
 |-----|------|-------|------|
-| wal.mode | 否 | false | 是否启用 WAL 逻辑解码模式；生产 CDC 建议显式配置为 `true` |
+| wal.mode | 否 | true | 是否启用 WAL 逻辑解码模式 |
 | decode.plugin | 否 | mppdb_decoding | 逻辑解码插件名称。支持：mppdb_decoding（默认）、pgoutput |
-| plugin.name | 否 | - | `decode.plugin` 的废弃兼容别名；不要同时配置两个参数 |
 | slot.name | 否 | flink_cdc_slot | 复制槽名称 |
 | snapshot.mode | 否 | true | 是否先读取全量快照 |
-| chunk.size | 否 | 1000 | 快照、轮询及 SQL WAL 读取使用的 JDBC fetch/page 大小 |
-
-### 输出格式参数
-
-| 参数 | 必填 | 默认值 | 说明 |
-|-----|------|-------|------|
-| output.format | 否 | raw | 输出类型：`raw` 表示按源表固定字段输出 RowData；`json` 表示输出单列 JSON 字符串 |
-| output.json.format | 否 | debezium | `output.format=json` 时生效。支持：`debezium`（Debezium 标准 JSON）、`canal`（Canal 标准 JSON） |
-
-固定字段输出使用默认配置即可：
-
-```sql
-'output.format' = 'raw'
-```
-
-Debezium 标准 JSON：
-
-```sql
-'output.format' = 'json',
-'output.json.format' = 'debezium'
-```
-
-Canal 标准 JSON：
-
-```sql
-'output.format' = 'json',
-'output.json.format' = 'canal'
-```
-
-> `output.format=json` 时，CDC 源表应定义为单个 `STRING` 类型的输出字段。
-> `output.format=raw` 时，`output.json.format` 不生效。
+| chunk.size | 否 | 1000 | 分块大小 |
 
 ### 并行解码参数（WAL 模式）
 

--- a/flink-connector-gaussdb-cdc-1.17/README.md
+++ b/flink-connector-gaussdb-cdc-1.17/README.md
@@ -350,11 +350,42 @@ CREATE TABLE student (
 
 | 参数 | 必填 | 默认值 | 说明 |
 |-----|------|-------|------|
-| wal.mode | 否 | true | 是否启用 WAL 逻辑解码模式 |
+| wal.mode | 否 | false | 是否启用 WAL 逻辑解码模式；生产 CDC 建议显式配置为 `true` |
 | decode.plugin | 否 | mppdb_decoding | 逻辑解码插件名称。支持：mppdb_decoding（默认）、pgoutput |
+| plugin.name | 否 | - | `decode.plugin` 的废弃兼容别名；不要同时配置两个参数 |
 | slot.name | 否 | flink_cdc_slot | 复制槽名称 |
 | snapshot.mode | 否 | true | 是否先读取全量快照 |
-| chunk.size | 否 | 1000 | 分块大小 |
+| chunk.size | 否 | 1000 | 快照、轮询及 SQL WAL 读取使用的 JDBC fetch/page 大小 |
+
+### 输出格式参数
+
+| 参数 | 必填 | 默认值 | 说明 |
+|-----|------|-------|------|
+| output.format | 否 | raw | 输出类型：`raw` 表示按源表固定字段输出 RowData；`json` 表示输出单列 JSON 字符串 |
+| output.json.format | 否 | debezium | `output.format=json` 时生效。支持：`debezium`（Debezium 标准 JSON）、`canal`（Canal 标准 JSON） |
+
+固定字段输出使用默认配置即可：
+
+```sql
+'output.format' = 'raw'
+```
+
+Debezium 标准 JSON：
+
+```sql
+'output.format' = 'json',
+'output.json.format' = 'debezium'
+```
+
+Canal 标准 JSON：
+
+```sql
+'output.format' = 'json',
+'output.json.format' = 'canal'
+```
+
+> `output.format=json` 时，CDC 源表应定义为单个 `STRING` 类型的输出字段。
+> `output.format=raw` 时，`output.json.format` 不生效。
 
 ### 并行解码参数（WAL 模式）
 

--- a/flink-connector-gaussdb-cdc-2.4.x/README.md
+++ b/flink-connector-gaussdb-cdc-2.4.x/README.md
@@ -1,0 +1,209 @@
+# Flink GaussDB CDC Connector 2.4.x
+
+GaussDB CDC 连接器，支持 Flink 2.4.x，基于 WAL 逻辑解码（mppdb_decoding）实时捕获数据变更。
+
+## 核心特性
+
+- **多表捕获**：支持正则匹配多张表，同时捕获异构表结构（不同 schema 的表）
+- **三种 JSON 输出格式**：Debezium、Canal、HE（自定义 Canal 变体）
+- **WAL 双通道**：流式复制 API（高吞吐）+ SQL 函数模式（零额外配置）
+- **轮询模式**：wal.mode=false 时使用基于轮询的 CDC，无需 WAL 逻辑解码
+- **Exactly-Once**：checkpoint 完成后才确认 WAL LSN，保证数据不丢
+- **SQL 注入防护**：所有标识符自动引用，兼容 M-compatible 模式
+
+## 版本兼容性
+
+| 连接器版本 | Flink 版本 | GaussDB 版本 | JAR 包 |
+|-----------|-----------|-------------|--------|
+| flink-connector-gaussdb-cdc-2.4.x | 2.4.x | 505.2.1.SPC0800+ | fat (1.7MB) / thin (100KB) |
+
+## 前置条件
+
+### 系统要求
+- JDK 8/11
+- Flink 2.4.x
+
+### 数据库要求
+
+#### WAL 逻辑解码模式（wal.mode=true）
+- GaussDB `wal_level = logical`
+- 用户有 REPLICATION 权限
+- 创建逻辑复制槽：`SELECT pg_create_logical_replication_slot('flink_cdc_slot', 'mppdb_decoding');`
+- 流式复制 API 模式额外需要 gs_hba.conf 白名单（见 CDC 1.17 README 详述）
+
+#### 轮询模式（wal.mode=false，默认）
+- 无需 WAL 配置，通过定期查询表数据捕获变更
+- 表必须有主键
+
+## JAR 包说明
+
+### fat 包（推荐）
+`flink-connector-gaussdb-cdc-2.4.x-3.3.0-1.20-fat.jar`（1.7MB）
+- 内置 GaussDB JDBC 驱动，部署时只需此一个 JAR + Flink 自带的 connector-base
+
+### thin 包
+`flink-connector-gaussdb-cdc-2.4.x-3.3.0-1.20-thin.jar`（100KB）
+- 不含 JDBC 驱动，需额外部署 `gaussdbjdbc-506.0.0.b058-jdk7.jar`
+
+```bash
+# fat 包部署
+cp flink-connector-gaussdb-cdc-2.4.x-3.3.0-1.20-fat.jar $FLINK_HOME/lib/
+
+# thin 包部署
+cp flink-connector-gaussdb-cdc-2.4.x-3.3.0-1.20-thin.jar $FLINK_HOME/lib/
+cp gaussdbjdbc-506.0.0.b058-jdk7.jar $FLINK_HOME/lib/
+```
+
+## 配置参数
+
+### 通用参数
+
+| 参数 | 必填 | 默认值 | 说明 |
+|-----|------|-------|------|
+| connector | 是 | - | 连接器类型：`gaussdb-cdc` |
+| hostname | 是 | - | GaussDB 主机地址 |
+| port | 否 | 8000 | GaussDB 端口 |
+| replication.port | 否 | - | WAL 流式复制专用端口（HA 端口） |
+| database | 是 | - | 数据库名 |
+| schema | 否 | public | Schema 名称 |
+| table-name | 是 | - | 表名，支持正则匹配多表 |
+| username | 是 | - | 用户名 |
+| password | 是 | - | 密码 |
+| sslmode | 否 | prefer | SSL 连接模式 |
+
+### CDC 参数
+
+| 参数 | 必填 | 默认值 | 说明 |
+|-----|------|-------|------|
+| wal.mode | 否 | false | 是否启用 WAL 逻辑解码模式；false 时使用轮询模式 |
+| decode.plugin | 否 | mppdb_decoding | 逻辑解码插件名称 |
+| plugin.name | 否 | - | `decode.plugin` 的废弃别名，不要同时配置 |
+| slot.name | 否 | flink_cdc_slot | 复制槽名称 |
+| snapshot.mode | 否 | true | 是否先读取全量快照 |
+| chunk.size | 否 | 1000 | 快照/轮询 JDBC fetch 大小 |
+| poll.interval.ms | 否 | 1000 | 轮询间隔（毫秒） |
+| connect.timeout.ms | 否 | 30000 | 连接超时（毫秒） |
+
+### 输出格式参数
+
+| 参数 | 必填 | 默认值 | 说明 |
+|-----|------|-------|------|
+| output.format | 否 | raw | 输出类型：`raw`（固定字段 RowData）/ `json`（单列 JSON 字符串） |
+| output.json.format | 否 | debezium | `output.format=json` 时生效，见下方详细说明 |
+
+#### output.format=raw（默认）
+按源表字段输出 RowData，要求所有表结构相同（同构表）。
+
+#### output.format=json
+输出单列 STRING 类型 JSON，支持异构表（不同 schema 的表）。CDC 源表需定义为单个 STRING 字段。
+
+`output.json.format` 支持三种格式：
+
+**debezium**（默认）— Debezium 标准 JSON，兼容 Flink CDC debezium-json 格式
+```json
+{"before":null,"after":{"id":"1","name":"Alice"},
+ "source":{"connector":"gaussdb","db":"postgres","schema":"sqlbuilder1","table":"orders","ts_ms":1784336396664},
+ "op":"c","ts_ms":1784336396664}
+```
+
+**canal** — Alibaba Canal 标准 JSON
+```json
+{"data":{"id":"1","name":"Alice"},"old":null,
+ "database":"postgres","table":"orders","type":"INSERT",
+ "pkNames":["id"],"es":1784336549776,"ts":1784336549776,
+ "isDdl":false,"sqlType":{},"mysqlType":{}}
+```
+
+**he** — 基于 Canal 的自定义格式
+```json
+{"database":"postgres","table":"orders",
+ "optType":"INSERT","pkNames":["id"],"pkValues":"1",
+ "es":1784336578232,"ts":1784336578232,
+ "data":{"id":"1","name":"Alice"},"old":null}
+```
+
+三种格式对比：
+
+| 字段 | debezium | canal | he |
+|------|----------|-------|-----|
+| 操作类型字段 | `op`（c/u/d） | `type`（INSERT/UPDATE/DELETE） | `optType`（INSERT/UPDATE/DELETE） |
+| 变更后数据 | `after` | `data` | `data` |
+| 变更前数据 | `before` | `old` | `old` |
+| 主键值 | 无 | `pkNames` | `pkNames` + `pkValues` |
+| DDL 标记 | 无 | `isDdl` | 无 |
+| 类型映射 | 无 | `sqlType`/`mysqlType` | 无 |
+
+> `he` 格式将 `type` 改为 `optType` 避免与业务字段名 `type` 冲突，并增加 `pkValues` 字段。
+
+### 并行解码参数（WAL 模式）
+
+| 参数 | 默认值 | 说明 |
+|-----|-------|------|
+| parallel-decode-num | 1 | 并行解码线程数，1~20 |
+| decode-style | b | 解码格式：b=binary，j=json，t=text（仅流式复制 API 模式生效） |
+| sending-batch | false | 批量发送，true=累积到 1MB 后发送（仅流式复制 API 模式生效） |
+
+## 多表捕获示例
+
+### 同构多表（raw 格式）
+
+```sql
+CREATE TABLE orders_cdc (
+    id INT,
+    name STRING,
+    PRIMARY KEY (id) NOT ENFORCED
+) WITH (
+    'connector' = 'gaussdb-cdc',
+    'hostname' = 'localhost',
+    'port' = '8000',
+    'database' = 'test',
+    'schema' = 'public',
+    'table-name' = 'orders_.*',
+    'username' = 'root',
+    'password' = 'password',
+    'wal.mode' = 'true',
+    'slot.name' = 'flink_cdc_slot'
+);
+```
+
+### 异构多表（json 格式）
+
+```sql
+CREATE TABLE cdc_events (
+    data STRING
+) WITH (
+    'connector' = 'gaussdb-cdc',
+    'hostname' = 'localhost',
+    'port' = '8000',
+    'database' = 'test',
+    'schema' = 'public',
+    'table-name' = 'orders_.*|products_.*',
+    'username' = 'root',
+    'password' = 'password',
+    'wal.mode' = 'true',
+    'slot.name' = 'flink_cdc_slot',
+    'output.format' = 'json',
+    'output.json.format' = 'he'
+);
+```
+
+## REPLICA IDENTITY 与 old 字段
+
+默认情况下，UPDATE/DELETE 的 `old`/`before` 字段只包含主键列。获取完整旧值需：
+
+```sql
+ALTER TABLE my_table REPLICA IDENTITY FULL;
+```
+
+## 注意事项
+
+1. **table-name 正则匹配**：含正则元字符（`.*+?^$[]()|\\`）时按正则匹配，否则按精确匹配（向后兼容）
+2. **复合主键**：不支持复合主键，会报错提示
+3. **非数字主键**：自动回退到单 subtask 快照，不做并行范围切分
+4. **Schema 变更**：WAL 重连后检测到表结构变化会报错，防止输出错误数据
+5. **Flink blob 缓存**：替换 JAR 后需完整重启集群（stop-cluster.sh + start-cluster.sh）
+6. **事务缓冲延迟**：WAL 事件在 COMMIT 读取后才输出，单条 INSERT 可能延迟到下次 WAL 读取周期
+
+## 许可证
+
+Apache License 2.0

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/GaussDBCDCOptions.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/GaussDBCDCOptions.java
@@ -99,6 +99,19 @@ public class GaussDBCDCOptions {
                                     + "with table name, operation type, and column values "
                                     + "(supports heterogeneous tables with different schemas).");
 
+    public static final ConfigOption<String> OUTPUT_JSON_FORMAT =
+            ConfigOptions.key("output.json.format")
+                    .stringType()
+                    .defaultValue("debezium")
+                    .withDescription(
+                            "JSON output format when output.format=json. "
+                                    + "'debezium' (default): Debezium standard format "
+                                    + "(before/after/source/op/ts_ms), compatible with Flink CDC. "
+                                    + "'canal': Canal standard format "
+                                    + "(data/old/database/table/type/es/ts/pkNames/isDdl/sqlType). "
+                                    + "'haier': Haier customized Canal format "
+                                    + "(data/old/database/table/optType/es/ts/pkNames/pkValues).");
+
     public static final ConfigOption<String> SLOT_NAME =
             ConfigOptions.key("slot.name")
                     .stringType()

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/GaussDBCDCOptions.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/GaussDBCDCOptions.java
@@ -109,7 +109,7 @@ public class GaussDBCDCOptions {
                                     + "(before/after/source/op/ts_ms), compatible with Flink CDC. "
                                     + "'canal': Canal standard format "
                                     + "(data/old/database/table/type/es/ts/pkNames/isDdl/sqlType). "
-                                    + "'haier': Haier customized Canal format "
+                                    + "'he': customized Canal format "
                                     + "(data/old/database/table/optType/es/ts/pkNames/pkValues).");
 
     public static final ConfigOption<String> SLOT_NAME =
@@ -121,8 +121,9 @@ public class GaussDBCDCOptions {
     public static final ConfigOption<String> PLUGIN_NAME =
             ConfigOptions.key("plugin.name")
                     .stringType()
-                    .defaultValue("pgoutput")
-                    .withDescription("Name of the GaussDB logical decoding plugin.");
+                    .noDefaultValue()
+                    .withDescription(
+                            "Deprecated alias of decode.plugin. Do not configure both options.");
 
     public static final ConfigOption<Boolean> SNAPSHOT_MODE =
             ConfigOptions.key("snapshot.mode")
@@ -135,7 +136,8 @@ public class GaussDBCDCOptions {
             ConfigOptions.key("chunk.size")
                     .intType()
                     .defaultValue(1000)
-                    .withDescription("Number of rows to read in each chunk during snapshot.");
+                    .withDescription(
+                            "JDBC fetch/page size used by snapshot, polling, and SQL WAL reads.");
 
     public static final ConfigOption<Integer> CONNECT_TIMEOUT_MS =
             ConfigOptions.key("connect.timeout.ms")

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/GaussDBCDCOptions.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/GaussDBCDCOptions.java
@@ -80,7 +80,24 @@ public class GaussDBCDCOptions {
             ConfigOptions.key("table-name")
                     .stringType()
                     .noDefaultValue()
-                    .withDescription("Table name of the GaussDB table to monitor.");
+                    .withDescription(
+                            "Table name of the GaussDB table to monitor. "
+                                    + "Supports regex matching for multi-table capture, e.g. "
+                                    + "'orders_.*' matches all tables starting with 'orders_'. "
+                                    + "When no regex metacharacters are present, exact match "
+                                    + "is used (backward compatible with single-table mode).");
+
+    public static final ConfigOption<String> OUTPUT_FORMAT =
+            ConfigOptions.key("output.format")
+                    .stringType()
+                    .defaultValue("raw")
+                    .withDescription(
+                            "Output format for CDC events. "
+                                    + "'raw' (default): outputs RowData with fixed columns "
+                                    + "(requires homogeneous table schemas). "
+                                    + "'json': outputs a single STRING column containing JSON "
+                                    + "with table name, operation type, and column values "
+                                    + "(supports heterogeneous tables with different schemas).");
 
     public static final ConfigOption<String> SLOT_NAME =
             ConfigOptions.key("slot.name")

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/ChangeDataPoller.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/ChangeDataPoller.java
@@ -24,6 +24,7 @@ import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
 import org.apache.flink.table.data.StringData;
 import org.apache.flink.table.data.TimestampData;
+import org.apache.flink.types.RowKind;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -43,14 +44,19 @@ import java.util.Map;
 /**
  * Poller for change data capture from GaussDB.
  *
- * <p>This implementation uses a change tracking table approach:
+ * <p>This implementation supports multi-table polling. Each table maintains its own:
  *
  * <ul>
- *   <li>Requires a trigger or application to write changes to a shadow table
- *   <li>Or uses timestamp/version columns to detect changes
+ *   <li>Cached column list
+ *   <li>Primary key column name
+ *   <li>Last polled ID (for INSERT detection)
+ *   <li>Last polled timestamp (for UPDATE detection)
+ *   <li>In-memory snapshot (for DELETE detection)
  * </ul>
  *
- * <p>Alternative: Query-based CDC using history table
+ * <p>When outputFormat is "json", each change event is output as a single STRING column containing
+ * a JSON string with table name, operation type, and column values, instead of a fixed-schema
+ * RowData.
  */
 @Internal
 public class ChangeDataPoller {
@@ -59,218 +65,445 @@ public class ChangeDataPoller {
 
     private final Connection connection;
     private final String schema;
-    private final String tableName;
-    private final String primaryKeyColumn;
+    private final List<String> tableNames;
+    private final String outputFormat;
 
-    // Cached column list (resolved once on first access)
-    private String cachedColumns;
-
-    // Tracking state
-    private long lastPolledId = 0;
-    private Timestamp lastPolledTimestamp = new Timestamp(0);
-    private final Map<Object, RowData> currentSnapshot = new HashMap<>();
+    // Per-table state
+    private final Map<String, String> cachedColumns = new HashMap<>();
+    private final Map<String, String> cachedPkColumns = new HashMap<>();
+    private final Map<String, Long> lastPolledIds = new HashMap<>();
+    private final Map<String, Timestamp> lastPolledTimestamps = new HashMap<>();
+    private final Map<String, Map<Object, RowData>> snapshots = new HashMap<>();
 
     public ChangeDataPoller(
-            Connection connection, String schema, String tableName, String primaryKeyColumn) {
+            Connection connection, String schema, List<String> tableNames, String outputFormat) {
         this.connection = connection;
         this.schema = schema;
-        this.tableName = tableName;
-        this.primaryKeyColumn = primaryKeyColumn;
+        this.tableNames = tableNames;
+        this.outputFormat = outputFormat;
+        for (String tbl : tableNames) {
+            lastPolledIds.put(tbl, 0L);
+            lastPolledTimestamps.put(tbl, new Timestamp(0));
+            snapshots.put(tbl, new HashMap<>());
+        }
     }
 
-    /**
-     * Dynamically resolve the column list for the target table via JDBC metadata. The result is
-     * cached after the first call.
-     */
-    private String getTableColumns() throws SQLException {
-        if (cachedColumns != null) {
-            return cachedColumns;
+    /** Backward-compatible single-table constructor. */
+    public ChangeDataPoller(
+            Connection connection, String schema, String tableName, String primaryKeyColumn) {
+        this(connection, schema, java.util.Collections.singletonList(tableName), "raw");
+        if (primaryKeyColumn != null) {
+            cachedPkColumns.put(tableName, primaryKeyColumn);
+        }
+    }
+
+    /** Backward-compatible getter for first table's lastPolledId. */
+    public long getLastPolledId() {
+        return lastPolledIds.getOrDefault(tableNames.get(0), 0L);
+    }
+
+    /** Backward-compatible setter for first table's lastPolledId. */
+    public void setLastPolledId(long lastPolledId) {
+        lastPolledIds.put(tableNames.get(0), lastPolledId);
+    }
+
+    /** Resolve the column list for a table, cached after first access. */
+    private String getTableColumns(String tbl) throws SQLException {
+        if (cachedColumns.containsKey(tbl)) {
+            return cachedColumns.get(tbl);
         }
         DatabaseMetaData meta = connection.getMetaData();
         List<String> columns = new ArrayList<>();
-        try (ResultSet rs = meta.getColumns(null, schema, tableName, null)) {
+        try (ResultSet rs = meta.getColumns(null, schema, tbl, null)) {
             while (rs.next()) {
                 columns.add(rs.getString("COLUMN_NAME"));
             }
         }
         if (columns.isEmpty()) {
-            throw new SQLException("No columns found for table " + schema + "." + tableName);
+            throw new SQLException("No columns found for table " + schema + "." + tbl);
         }
-        cachedColumns = String.join(", ", columns);
-        return cachedColumns;
+        String joined = String.join(", ", columns);
+        cachedColumns.put(tbl, joined);
+        return joined;
     }
 
-    /** Poll for new inserts (based on auto-increment ID). */
-    public List<ChangeEvent<RowData>> pollNewInserts() throws SQLException {
-        List<ChangeEvent<RowData>> events = new ArrayList<>();
-
-        String columns = getTableColumns();
-        String sql =
-                String.format(
-                        "SELECT %s FROM %s.%s WHERE %s > ? ORDER BY %s LIMIT 1000",
-                        columns, schema, tableName, primaryKeyColumn, primaryKeyColumn);
-
-        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
-            stmt.setLong(1, lastPolledId);
-
-            try (ResultSet rs = stmt.executeQuery()) {
-                ResultSetMetaData meta = rs.getMetaData();
-                while (rs.next()) {
-                    RowData row = convertToRowDataDynamic(rs, meta);
-                    long id = rs.getLong(primaryKeyColumn);
-
-                    events.add(ChangeEvent.insert(tableName, row, System.currentTimeMillis()));
-                    currentSnapshot.put(id, row);
-                    lastPolledId = id;
+    /** Detect primary key column for a table, cached after first access. */
+    private String getPrimaryKeyColumn(String tbl) throws SQLException {
+        if (cachedPkColumns.containsKey(tbl)) {
+            return cachedPkColumns.get(tbl);
+        }
+        // Try DatabaseMetaData
+        try {
+            DatabaseMetaData meta = connection.getMetaData();
+            ResultSet pkRs = meta.getPrimaryKeys(null, schema, tbl);
+            if (pkRs != null) {
+                try (ResultSet rs = pkRs) {
+                    if (rs.next()) {
+                        String pkName = rs.getString("COLUMN_NAME");
+                        if (pkName != null && !pkName.isEmpty()) {
+                            cachedPkColumns.put(tbl, pkName);
+                            return pkName;
+                        }
+                    }
                 }
             }
+        } catch (SQLException e) {
+            LOG.warn("Failed to detect PK for {}.{}: {}", schema, tbl, e.getMessage());
         }
+        // Fallback: pg_index
+        try (PreparedStatement stmt =
+                connection.prepareStatement(
+                        "SELECT a.attname FROM pg_index i "
+                                + "JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) "
+                                + "WHERE i.indrelid = ?::regclass AND i.indisprimary LIMIT 1")) {
+            stmt.setString(1, schema + "." + tbl);
+            try (ResultSet rs = stmt.executeQuery()) {
+                if (rs.next()) {
+                    String pkName = rs.getString(1);
+                    if (pkName != null && !pkName.isEmpty()) {
+                        cachedPkColumns.put(tbl, pkName);
+                        return pkName;
+                    }
+                }
+            }
+        } catch (SQLException e) {
+            LOG.warn("pg_index PK detection failed for {}.{}: {}", schema, tbl, e.getMessage());
+        }
+        LOG.warn("No PK found for {}.{}; falling back to \"id\"", schema, tbl);
+        cachedPkColumns.put(tbl, "id");
+        return "id";
+    }
 
+    /** Poll for new inserts across all tables. */
+    public List<ChangeEvent<RowData>> pollNewInserts() throws SQLException {
+        List<ChangeEvent<RowData>> events = new ArrayList<>();
+        for (String tbl : tableNames) {
+            events.addAll(pollInsertsForTable(tbl));
+        }
         return events;
     }
 
-    /** Poll for updates (based on updated_at timestamp, if available). */
+    private List<ChangeEvent<RowData>> pollInsertsForTable(String tbl) throws SQLException {
+        List<ChangeEvent<RowData>> events = new ArrayList<>();
+        String columns = getTableColumns(tbl);
+        String pkCol = getPrimaryKeyColumn(tbl);
+        long lastId = lastPolledIds.get(tbl);
+        Map<Object, RowData> snapshot = snapshots.get(tbl);
+
+        String sql =
+                String.format(
+                        "SELECT %s FROM %s.%s WHERE %s > ? ORDER BY %s LIMIT 1000",
+                        columns, schema, tbl, pkCol, pkCol);
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setLong(1, lastId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                ResultSetMetaData meta = rs.getMetaData();
+                while (rs.next()) {
+                    RowData row;
+                    if ("json".equalsIgnoreCase(outputFormat)) {
+                        row = convertToJsonRow(tbl, "INSERT", null, rs, meta);
+                    } else {
+                        row = convertToRowDataDynamic(rs, meta);
+                    }
+                    events.add(ChangeEvent.insert(tbl, row, System.currentTimeMillis()));
+                    long id = rs.getLong(pkCol);
+                    snapshot.put(id, row);
+                    lastPolledIds.put(tbl, id);
+                }
+            }
+        }
+        return events;
+    }
+
+    /** Poll for updates across all tables. */
     public List<ChangeEvent<RowData>> pollUpdates() throws SQLException {
         List<ChangeEvent<RowData>> events = new ArrayList<>();
+        for (String tbl : tableNames) {
+            try {
+                events.addAll(pollUpdatesForTable(tbl));
+            } catch (SQLException e) {
+                LOG.warn("Could not poll updates for {}.{}: {}", schema, tbl, e.getMessage());
+            }
+        }
+        return events;
+    }
 
-        // Check if table has an 'updated_at' column; skip if not
-        String columns = getTableColumns();
+    private List<ChangeEvent<RowData>> pollUpdatesForTable(String tbl) throws SQLException {
+        List<ChangeEvent<RowData>> events = new ArrayList<>();
+        String columns = getTableColumns(tbl);
         if (!columns.toLowerCase().contains("updated_at")) {
-            LOG.warn(
-                    "Table {}.{} has no 'updated_at' column; skipping update polling",
-                    schema,
-                    tableName);
             return events;
         }
+        String pkCol = getPrimaryKeyColumn(tbl);
+        Timestamp lastTs = lastPolledTimestamps.get(tbl);
+        Map<Object, RowData> snapshot = snapshots.get(tbl);
+
         String sql =
                 String.format(
                         "SELECT %s FROM %s.%s WHERE updated_at > ? ORDER BY updated_at LIMIT 1000",
-                        columns, schema, tableName);
-
+                        columns, schema, tbl);
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
-            stmt.setTimestamp(1, lastPolledTimestamp);
-
+            stmt.setTimestamp(1, lastTs);
             try (ResultSet rs = stmt.executeQuery()) {
                 ResultSetMetaData meta = rs.getMetaData();
                 while (rs.next()) {
                     RowData newRow = convertToRowDataDynamic(rs, meta);
-                    long id = rs.getLong(primaryKeyColumn);
+                    long id = rs.getLong(pkCol);
                     Timestamp updatedAt = rs.getTimestamp("updated_at");
-
-                    RowData oldRow = currentSnapshot.get(id);
+                    RowData oldRow = snapshot.get(id);
 
                     if (oldRow != null) {
-                        // This is an UPDATE
-                        events.add(
-                                ChangeEvent.update(
-                                        tableName, oldRow, newRow, System.currentTimeMillis()));
+                        if ("json".equalsIgnoreCase(outputFormat)) {
+                            RowData jsonRow = convertToJsonRow(tbl, "UPDATE", oldRow, rs, meta);
+                            events.add(
+                                    ChangeEvent.update(
+                                            tbl, oldRow, jsonRow, System.currentTimeMillis()));
+                        } else {
+                            events.add(
+                                    ChangeEvent.update(
+                                            tbl, oldRow, newRow, System.currentTimeMillis()));
+                        }
                     } else {
-                        // This might be an INSERT that we missed, or initial load
-                        events.add(
-                                ChangeEvent.insert(tableName, newRow, System.currentTimeMillis()));
+                        if ("json".equalsIgnoreCase(outputFormat)) {
+                            RowData jsonRow = convertToJsonRow(tbl, "INSERT", null, rs, meta);
+                            events.add(
+                                    ChangeEvent.insert(tbl, jsonRow, System.currentTimeMillis()));
+                        } else {
+                            events.add(ChangeEvent.insert(tbl, newRow, System.currentTimeMillis()));
+                        }
                     }
-
-                    currentSnapshot.put(id, newRow);
+                    snapshot.put(id, newRow);
                     if (updatedAt != null) {
-                        lastPolledTimestamp = updatedAt;
+                        lastPolledTimestamps.put(tbl, updatedAt);
                     }
                 }
             }
         }
-
         return events;
     }
 
-    /**
-     * Poll for deletes by checking missing IDs. This requires querying all current IDs and
-     * comparing with snapshot.
-     */
+    /** Poll for deletes across all tables. */
     public List<ChangeEvent<RowData>> pollDeletes() throws SQLException {
         List<ChangeEvent<RowData>> events = new ArrayList<>();
+        for (String tbl : tableNames) {
+            events.addAll(pollDeletesForTable(tbl));
+        }
+        return events;
+    }
 
-        // Get all current IDs from database
-        String sql = String.format("SELECT %s FROM %s.%s", primaryKeyColumn, schema, tableName);
+    private List<ChangeEvent<RowData>> pollDeletesForTable(String tbl) throws SQLException {
+        List<ChangeEvent<RowData>> events = new ArrayList<>();
+        String pkCol = getPrimaryKeyColumn(tbl);
+        Map<Object, RowData> snapshot = snapshots.get(tbl);
+
+        String sql = String.format("SELECT %s FROM %s.%s", pkCol, schema, tbl);
         List<Long> currentIds = new ArrayList<>();
-
         try (PreparedStatement stmt = connection.prepareStatement(sql);
                 ResultSet rs = stmt.executeQuery()) {
             while (rs.next()) {
-                currentIds.add(rs.getLong(primaryKeyColumn));
+                currentIds.add(rs.getLong(pkCol));
             }
         }
-
-        // Find deleted IDs (in snapshot but not in current)
         List<Object> deletedIds = new ArrayList<>();
-        for (Object id : currentSnapshot.keySet()) {
+        for (Object id : snapshot.keySet()) {
             if (!currentIds.contains(id)) {
                 deletedIds.add(id);
             }
         }
-
-        // Emit delete events
         for (Object id : deletedIds) {
-            RowData deletedRow = currentSnapshot.remove(id);
+            RowData deletedRow = snapshot.remove(id);
             if (deletedRow != null) {
-                events.add(ChangeEvent.delete(tableName, deletedRow, System.currentTimeMillis()));
+                if ("json".equalsIgnoreCase(outputFormat)) {
+                    RowData jsonRow = convertToJsonRowForDelete(tbl, deletedRow);
+                    events.add(ChangeEvent.delete(tbl, jsonRow, System.currentTimeMillis()));
+                } else {
+                    if (deletedRow instanceof GenericRowData) {
+                        ((GenericRowData) deletedRow).setRowKind(RowKind.DELETE);
+                    }
+                    events.add(ChangeEvent.delete(tbl, deletedRow, System.currentTimeMillis()));
+                }
             }
         }
-
         return events;
     }
 
-    /** Comprehensive poll for all change types. */
+    /** Comprehensive poll for all change types across all tables. */
     public List<ChangeEvent<RowData>> pollAllChanges() throws SQLException {
         List<ChangeEvent<RowData>> allEvents = new ArrayList<>();
-
-        // Poll new inserts
         allEvents.addAll(pollNewInserts());
-
-        // Poll updates (requires updated_at column)
-        try {
-            allEvents.addAll(pollUpdates());
-        } catch (SQLException e) {
-            LOG.warn(
-                    "Could not poll updates, 'updated_at' column may not exist: {}",
-                    e.getMessage());
-        }
-
-        // Poll deletes (expensive operation, do less frequently)
+        allEvents.addAll(pollUpdates());
         allEvents.addAll(pollDeletes());
-
         return allEvents;
     }
 
-    /** Load initial snapshot into memory for change detection. */
+    /** Load initial snapshot for all tables into memory. */
     public void loadSnapshot() throws SQLException {
-        currentSnapshot.clear();
+        for (String tbl : tableNames) {
+            loadSnapshotForTable(tbl);
+        }
+    }
 
-        String columns = getTableColumns();
-        String sql = String.format("SELECT %s FROM %s.%s", columns, schema, tableName);
+    private void loadSnapshotForTable(String tbl) throws SQLException {
+        Map<Object, RowData> snapshot = snapshots.get(tbl);
+        snapshot.clear();
+        String columns = getTableColumns(tbl);
+        String pkCol = getPrimaryKeyColumn(tbl);
+        long maxId = 0;
 
+        String sql = String.format("SELECT %s FROM %s.%s", columns, schema, tbl);
         try (PreparedStatement stmt = connection.prepareStatement(sql);
                 ResultSet rs = stmt.executeQuery()) {
             ResultSetMetaData meta = rs.getMetaData();
             while (rs.next()) {
-                long id = rs.getLong(primaryKeyColumn);
+                long id = rs.getLong(pkCol);
                 RowData row = convertToRowDataDynamic(rs, meta);
-                currentSnapshot.put(id, row);
-
-                if (id > lastPolledId) {
-                    lastPolledId = id;
+                snapshot.put(id, row);
+                if (id > maxId) {
+                    maxId = id;
                 }
             }
         }
-
+        // Only update lastPolledId if we actually loaded rows;
+        // preserve existing value for empty tables (backward compatible)
+        if (snapshot.size() > 0 || lastPolledIds.get(tbl) == 0L) {
+            lastPolledIds.put(tbl, maxId);
+        }
         LOG.info(
-                "Loaded snapshot with {} rows, lastPolledId={}",
-                currentSnapshot.size(),
-                lastPolledId);
+                "Loaded snapshot for {}.{}: {} rows, lastId={}",
+                schema,
+                tbl,
+                snapshot.size(),
+                lastPolledIds.get(tbl));
     }
 
-    /**
-     * Dynamically convert a ResultSet row to GenericRowData using ResultSetMetaData. This replaces
-     * the old hardcoded convertToRowData that assumed a fixed schema.
-     */
+    // ---- JSON output helpers ----
+
+    private RowData convertToJsonRow(
+            String tbl, String op, RowData oldRow, ResultSet rs, ResultSetMetaData meta)
+            throws SQLException {
+        StringBuilder sb = new StringBuilder(256);
+        sb.append("{\"table\":\"").append(escapeJson(tbl)).append('"');
+        sb.append(",\"schema\":\"").append(escapeJson(schema)).append('"');
+        sb.append(",\"op\":\"").append(op).append('"');
+        // before
+        if (oldRow != null) {
+            sb.append(",\"before\":");
+            appendRowDataAsJson(sb, oldRow, meta);
+        } else {
+            sb.append(",\"before\":{}");
+        }
+        // after
+        sb.append(",\"after\":");
+        appendResultSetAsJson(sb, rs, meta);
+        sb.append('}');
+
+        GenericRowData row = new GenericRowData(1);
+        row.setField(0, StringData.fromString(sb.toString()));
+        return row;
+    }
+
+    private RowData convertToJsonRowForDelete(String tbl, RowData oldRow) {
+        StringBuilder sb = new StringBuilder(256);
+        sb.append("{\"table\":\"").append(escapeJson(tbl)).append('"');
+        sb.append(",\"schema\":\"").append(escapeJson(schema)).append('"');
+        sb.append(",\"op\":\"DELETE\"");
+        sb.append(",\"before\":");
+        // For delete, we don't have ResultSetMetaData here; serialize what we have
+        if (oldRow instanceof GenericRowData) {
+            GenericRowData gd = (GenericRowData) oldRow;
+            sb.append("{\"row\":\"").append(gd.toString()).append("\"}");
+        } else {
+            sb.append("{}");
+        }
+        sb.append(",\"after\":{}}");
+
+        GenericRowData row = new GenericRowData(1);
+        row.setField(0, StringData.fromString(sb.toString()));
+        row.setRowKind(RowKind.DELETE);
+        return row;
+    }
+
+    private void appendResultSetAsJson(StringBuilder sb, ResultSet rs, ResultSetMetaData meta)
+            throws SQLException {
+        sb.append('{');
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
+            if (i > 1) {
+                sb.append(',');
+            }
+            String colName = meta.getColumnName(i);
+            sb.append('"').append(escapeJson(colName)).append("\":");
+            String val = rs.getString(i);
+            if (rs.wasNull()) {
+                sb.append("null");
+            } else {
+                sb.append('"').append(escapeJson(val)).append('"');
+            }
+        }
+        sb.append('}');
+    }
+
+    private void appendRowDataAsJson(StringBuilder sb, RowData row, ResultSetMetaData meta)
+            throws SQLException {
+        if (!(row instanceof GenericRowData)) {
+            sb.append("{}");
+            return;
+        }
+        GenericRowData gd = (GenericRowData) row;
+        sb.append('{');
+        for (int i = 0; i < gd.getArity() && i < meta.getColumnCount(); i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            String colName = meta.getColumnName(i + 1);
+            sb.append('"').append(escapeJson(colName)).append("\":");
+            Object val = gd.getField(i);
+            if (val == null) {
+                sb.append("null");
+            } else if (val instanceof StringData) {
+                sb.append('"').append(escapeJson(((StringData) val).toString())).append('"');
+            } else {
+                sb.append('"').append(escapeJson(String.valueOf(val))).append('"');
+            }
+        }
+        sb.append('}');
+    }
+
+    private String escapeJson(String s) {
+        if (s == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(s.length() + 16);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
+    }
+
+    // ---- Standard RowData conversion (raw mode) ----
+
     private RowData convertToRowDataDynamic(ResultSet rs, ResultSetMetaData meta)
             throws SQLException {
         int colCount = meta.getColumnCount();
@@ -343,18 +576,8 @@ public class ChangeDataPoller {
                     value = fallback != null ? StringData.fromString(fallback) : null;
                     break;
             }
-
             row.setField(i - 1, value);
         }
-
         return row;
-    }
-
-    public void setLastPolledId(long lastPolledId) {
-        this.lastPolledId = lastPolledId;
-    }
-
-    public long getLastPolledId() {
-        return lastPolledId;
     }
 }

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/ChangeDataPoller.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/ChangeDataPoller.java
@@ -29,6 +29,12 @@ import org.apache.flink.types.RowKind;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
+import java.io.Serializable;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
@@ -38,8 +44,10 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Poller for change data capture from GaussDB.
@@ -62,28 +70,70 @@ import java.util.Map;
 public class ChangeDataPoller {
 
     private static final Logger LOG = LoggerFactory.getLogger(ChangeDataPoller.class);
+    private static final int DEFAULT_BATCH_SIZE = 1000;
 
     private final Connection connection;
+    private final String database;
     private final String schema;
     private final List<String> tableNames;
     private final String outputFormat;
+    private final String outputJsonFormat;
+    private final int batchSize;
+    private String identifierQuoteString;
 
     // Per-table state
     private final Map<String, String> cachedColumns = new HashMap<>();
+    private final Map<String, List<String>> cachedColumnNames = new HashMap<>();
     private final Map<String, String> cachedPkColumns = new HashMap<>();
-    private final Map<String, Long> lastPolledIds = new HashMap<>();
+    private final Map<String, Object> lastPolledKeys = new HashMap<>();
     private final Map<String, Timestamp> lastPolledTimestamps = new HashMap<>();
+    private final Map<String, Object> lastPolledUpdateKeys = new HashMap<>();
     private final Map<String, Map<Object, RowData>> snapshots = new HashMap<>();
 
     public ChangeDataPoller(
             Connection connection, String schema, List<String> tableNames, String outputFormat) {
+        this(connection, null, schema, tableNames, outputFormat, "debezium", DEFAULT_BATCH_SIZE);
+    }
+
+    public ChangeDataPoller(
+            Connection connection,
+            String database,
+            String schema,
+            List<String> tableNames,
+            String outputFormat,
+            String outputJsonFormat) {
+        this(
+                connection,
+                database,
+                schema,
+                tableNames,
+                outputFormat,
+                outputJsonFormat,
+                DEFAULT_BATCH_SIZE);
+    }
+
+    public ChangeDataPoller(
+            Connection connection,
+            String database,
+            String schema,
+            List<String> tableNames,
+            String outputFormat,
+            String outputJsonFormat,
+            int batchSize) {
         this.connection = connection;
+        this.database = database;
         this.schema = schema;
         this.tableNames = tableNames;
         this.outputFormat = outputFormat;
+        this.outputJsonFormat = outputJsonFormat;
+        if (batchSize <= 0) {
+            throw new IllegalArgumentException("batchSize must be greater than zero");
+        }
+        this.batchSize = batchSize;
         for (String tbl : tableNames) {
-            lastPolledIds.put(tbl, 0L);
+            lastPolledKeys.put(tbl, null);
             lastPolledTimestamps.put(tbl, new Timestamp(0));
+            lastPolledUpdateKeys.put(tbl, null);
             snapshots.put(tbl, new HashMap<>());
         }
     }
@@ -94,17 +144,21 @@ public class ChangeDataPoller {
         this(connection, schema, java.util.Collections.singletonList(tableName), "raw");
         if (primaryKeyColumn != null) {
             cachedPkColumns.put(tableName, primaryKeyColumn);
+            // Preserve the legacy single-table poller's numeric starting cursor. Generic
+            // multi-table construction starts from null and supports non-numeric keys.
+            lastPolledKeys.put(tableName, 0L);
         }
     }
 
     /** Backward-compatible getter for first table's lastPolledId. */
     public long getLastPolledId() {
-        return lastPolledIds.getOrDefault(tableNames.get(0), 0L);
+        Object value = lastPolledKeys.get(tableNames.get(0));
+        return value instanceof Number ? ((Number) value).longValue() : 0L;
     }
 
     /** Backward-compatible setter for first table's lastPolledId. */
     public void setLastPolledId(long lastPolledId) {
-        lastPolledIds.put(tableNames.get(0), lastPolledId);
+        lastPolledKeys.put(tableNames.get(0), lastPolledId);
     }
 
     /** Resolve the column list for a table, cached after first access. */
@@ -122,9 +176,43 @@ public class ChangeDataPoller {
         if (columns.isEmpty()) {
             throw new SQLException("No columns found for table " + schema + "." + tbl);
         }
-        String joined = String.join(", ", columns);
+        String joined = quoteColumnList(columns);
+        cachedColumnNames.put(tbl, columns);
         cachedColumns.put(tbl, joined);
         return joined;
+    }
+
+    private String identifierQuoteString() throws SQLException {
+        if (identifierQuoteString == null) {
+            identifierQuoteString = SqlIdentifierUtils.resolveQuoteString(connection);
+        }
+        return identifierQuoteString;
+    }
+
+    private String quoteIdentifier(String identifier) throws SQLException {
+        return SqlIdentifierUtils.quote(identifier, identifierQuoteString());
+    }
+
+    private String qualifiedTable(String tbl) throws SQLException {
+        return SqlIdentifierUtils.qualified(schema, tbl, identifierQuoteString());
+    }
+
+    private String quoteColumnList(List<String> columns) throws SQLException {
+        return SqlIdentifierUtils.columnList(columns, identifierQuoteString());
+    }
+
+    private boolean hasColumn(String tbl, String columnName) throws SQLException {
+        return findColumnName(tbl, columnName) != null;
+    }
+
+    private String findColumnName(String tbl, String columnName) throws SQLException {
+        getTableColumns(tbl);
+        for (String column : cachedColumnNames.get(tbl)) {
+            if (column.equalsIgnoreCase(columnName)) {
+                return column;
+            }
+        }
+        return null;
     }
 
     /** Detect primary key column for a table, cached after first access. */
@@ -132,22 +220,40 @@ public class ChangeDataPoller {
         if (cachedPkColumns.containsKey(tbl)) {
             return cachedPkColumns.get(tbl);
         }
-        // Try DatabaseMetaData
+        // Polling cursors require one deterministic key. Reject composite/no-PK tables explicitly
+        // instead of silently using the first key column or a possibly non-existent "id" column.
         try {
             DatabaseMetaData meta = connection.getMetaData();
             ResultSet pkRs = meta.getPrimaryKeys(null, schema, tbl);
             if (pkRs != null) {
                 try (ResultSet rs = pkRs) {
-                    if (rs.next()) {
+                    List<String> pkColumns = new ArrayList<>();
+                    while (rs.next()) {
                         String pkName = rs.getString("COLUMN_NAME");
                         if (pkName != null && !pkName.isEmpty()) {
-                            cachedPkColumns.put(tbl, pkName);
-                            return pkName;
+                            pkColumns.add(pkName);
                         }
+                    }
+                    if (pkColumns.size() == 1) {
+                        cachedPkColumns.put(tbl, pkColumns.get(0));
+                        return pkColumns.get(0);
+                    }
+                    if (pkColumns.size() > 1) {
+                        throw new SQLException(
+                                "Polling CDC requires a single-column primary key for "
+                                        + schema
+                                        + "."
+                                        + tbl
+                                        + "; found composite key "
+                                        + pkColumns);
                     }
                 }
             }
         } catch (SQLException e) {
+            if (e.getMessage() != null
+                    && e.getMessage().startsWith("Polling CDC requires a single-column")) {
+                throw e;
+            }
             LOG.warn("Failed to detect PK for {}.{}: {}", schema, tbl, e.getMessage());
         }
         // Fallback: pg_index
@@ -155,23 +261,43 @@ public class ChangeDataPoller {
                 connection.prepareStatement(
                         "SELECT a.attname FROM pg_index i "
                                 + "JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) "
-                                + "WHERE i.indrelid = ?::regclass AND i.indisprimary LIMIT 1")) {
-            stmt.setString(1, schema + "." + tbl);
+                                + "JOIN pg_class c ON c.oid = i.indrelid "
+                                + "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                                + "WHERE n.nspname = ? AND c.relname = ? AND i.indisprimary "
+                                + "ORDER BY a.attnum")) {
+            stmt.setString(1, schema);
+            stmt.setString(2, tbl);
             try (ResultSet rs = stmt.executeQuery()) {
-                if (rs.next()) {
+                List<String> pkColumns = new ArrayList<>();
+                while (rs.next()) {
                     String pkName = rs.getString(1);
                     if (pkName != null && !pkName.isEmpty()) {
-                        cachedPkColumns.put(tbl, pkName);
-                        return pkName;
+                        pkColumns.add(pkName);
                     }
+                }
+                if (pkColumns.size() == 1) {
+                    cachedPkColumns.put(tbl, pkColumns.get(0));
+                    return pkColumns.get(0);
+                }
+                if (pkColumns.size() > 1) {
+                    throw new SQLException(
+                            "Polling CDC requires a single-column primary key for "
+                                    + schema
+                                    + "."
+                                    + tbl
+                                    + "; found composite key "
+                                    + pkColumns);
                 }
             }
         } catch (SQLException e) {
+            if (e.getMessage() != null
+                    && e.getMessage().startsWith("Polling CDC requires a single-column")) {
+                throw e;
+            }
             LOG.warn("pg_index PK detection failed for {}.{}: {}", schema, tbl, e.getMessage());
         }
-        LOG.warn("No PK found for {}.{}; falling back to \"id\"", schema, tbl);
-        cachedPkColumns.put(tbl, "id");
-        return "id";
+        throw new SQLException(
+                "Polling CDC requires a primary key, but none was found for " + schema + "." + tbl);
     }
 
     /** Poll for new inserts across all tables. */
@@ -187,28 +313,51 @@ public class ChangeDataPoller {
         List<ChangeEvent<RowData>> events = new ArrayList<>();
         String columns = getTableColumns(tbl);
         String pkCol = getPrimaryKeyColumn(tbl);
-        long lastId = lastPolledIds.get(tbl);
+        Object lastKey = lastPolledKeys.get(tbl);
         Map<Object, RowData> snapshot = snapshots.get(tbl);
 
-        String sql =
-                String.format(
-                        "SELECT %s FROM %s.%s WHERE %s > ? ORDER BY %s LIMIT 1000",
-                        columns, schema, tbl, pkCol, pkCol);
+        String sql;
+        if (lastKey == null) {
+            sql =
+                    String.format(
+                            "SELECT %s FROM %s ORDER BY %s LIMIT %d",
+                            columns, qualifiedTable(tbl), quoteIdentifier(pkCol), batchSize);
+        } else {
+            sql =
+                    String.format(
+                            "SELECT %s FROM %s WHERE %s > ? ORDER BY %s LIMIT %d",
+                            columns,
+                            qualifiedTable(tbl),
+                            quoteIdentifier(pkCol),
+                            quoteIdentifier(pkCol),
+                            batchSize);
+        }
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
-            stmt.setLong(1, lastId);
+            stmt.setFetchSize(batchSize);
+            if (lastKey != null) {
+                stmt.setObject(1, lastKey);
+            }
             try (ResultSet rs = stmt.executeQuery()) {
                 ResultSetMetaData meta = rs.getMetaData();
                 while (rs.next()) {
-                    RowData row;
-                    if ("json".equalsIgnoreCase(outputFormat)) {
-                        row = convertToJsonRow(tbl, "INSERT", null, rs, meta);
-                    } else {
-                        row = convertToRowDataDynamic(rs, meta);
+                    RowData rawRow = convertToRowDataDynamic(rs, meta);
+                    Object key = readPrimaryKey(rs, pkCol);
+                    // Update polling runs first and may already have discovered this newly inserted
+                    // row through updated_at. Do not emit it a second time when advancing the PK
+                    // cursor in the same cycle.
+                    if (!snapshot.containsKey(key)) {
+                        RowData emittedRow;
+                        if ("json".equalsIgnoreCase(outputFormat)) {
+                            emittedRow = convertToJsonRow(tbl, "INSERT", null, rs, meta);
+                        } else {
+                            emittedRow = rawRow;
+                        }
+                        events.add(ChangeEvent.insert(tbl, emittedRow, System.currentTimeMillis()));
                     }
-                    events.add(ChangeEvent.insert(tbl, row, System.currentTimeMillis()));
-                    long id = rs.getLong(pkCol);
-                    snapshot.put(id, row);
-                    lastPolledIds.put(tbl, id);
+                    // Always keep the raw row in the snapshot. JSON envelopes are output records,
+                    // not comparable table state and cannot be used to build UPDATE/DELETE images.
+                    snapshot.put(key, rawRow);
+                    lastPolledKeys.put(tbl, key);
                 }
             }
         }
@@ -219,11 +368,7 @@ public class ChangeDataPoller {
     public List<ChangeEvent<RowData>> pollUpdates() throws SQLException {
         List<ChangeEvent<RowData>> events = new ArrayList<>();
         for (String tbl : tableNames) {
-            try {
-                events.addAll(pollUpdatesForTable(tbl));
-            } catch (SQLException e) {
-                LOG.warn("Could not poll updates for {}.{}: {}", schema, tbl, e.getMessage());
-            }
+            events.addAll(pollUpdatesForTable(tbl));
         }
         return events;
     }
@@ -231,26 +376,54 @@ public class ChangeDataPoller {
     private List<ChangeEvent<RowData>> pollUpdatesForTable(String tbl) throws SQLException {
         List<ChangeEvent<RowData>> events = new ArrayList<>();
         String columns = getTableColumns(tbl);
-        if (!columns.toLowerCase().contains("updated_at")) {
+        if (!hasColumn(tbl, "updated_at")) {
             return events;
         }
+        String updatedAtColumn = findColumnName(tbl, "updated_at");
         String pkCol = getPrimaryKeyColumn(tbl);
         Timestamp lastTs = lastPolledTimestamps.get(tbl);
+        Object lastUpdateKey = lastPolledUpdateKeys.get(tbl);
         Map<Object, RowData> snapshot = snapshots.get(tbl);
 
-        String sql =
-                String.format(
-                        "SELECT %s FROM %s.%s WHERE updated_at > ? ORDER BY updated_at LIMIT 1000",
-                        columns, schema, tbl);
+        String sql;
+        if (lastUpdateKey == null) {
+            sql =
+                    String.format(
+                            "SELECT %s FROM %s WHERE %s > ? ORDER BY %s, %s LIMIT %d",
+                            columns,
+                            qualifiedTable(tbl),
+                            quoteIdentifier(updatedAtColumn),
+                            quoteIdentifier(updatedAtColumn),
+                            quoteIdentifier(pkCol),
+                            batchSize);
+        } else {
+            sql =
+                    String.format(
+                            "SELECT %s FROM %s WHERE %s > ? OR (%s = ? AND %s > ?) "
+                                    + "ORDER BY %s, %s LIMIT %d",
+                            columns,
+                            qualifiedTable(tbl),
+                            quoteIdentifier(updatedAtColumn),
+                            quoteIdentifier(updatedAtColumn),
+                            quoteIdentifier(pkCol),
+                            quoteIdentifier(updatedAtColumn),
+                            quoteIdentifier(pkCol),
+                            batchSize);
+        }
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setFetchSize(batchSize);
             stmt.setTimestamp(1, lastTs);
+            if (lastUpdateKey != null) {
+                stmt.setTimestamp(2, lastTs);
+                stmt.setObject(3, lastUpdateKey);
+            }
             try (ResultSet rs = stmt.executeQuery()) {
                 ResultSetMetaData meta = rs.getMetaData();
                 while (rs.next()) {
                     RowData newRow = convertToRowDataDynamic(rs, meta);
-                    long id = rs.getLong(pkCol);
-                    Timestamp updatedAt = rs.getTimestamp("updated_at");
-                    RowData oldRow = snapshot.get(id);
+                    Object key = readPrimaryKey(rs, pkCol);
+                    Timestamp updatedAt = rs.getTimestamp(updatedAtColumn);
+                    RowData oldRow = snapshot.get(key);
 
                     if (oldRow != null) {
                         if ("json".equalsIgnoreCase(outputFormat)) {
@@ -272,9 +445,10 @@ public class ChangeDataPoller {
                             events.add(ChangeEvent.insert(tbl, newRow, System.currentTimeMillis()));
                         }
                     }
-                    snapshot.put(id, newRow);
+                    snapshot.put(key, newRow);
                     if (updatedAt != null) {
                         lastPolledTimestamps.put(tbl, updatedAt);
+                        lastPolledUpdateKeys.put(tbl, key);
                     }
                 }
             }
@@ -296,12 +470,15 @@ public class ChangeDataPoller {
         String pkCol = getPrimaryKeyColumn(tbl);
         Map<Object, RowData> snapshot = snapshots.get(tbl);
 
-        String sql = String.format("SELECT %s FROM %s.%s", pkCol, schema, tbl);
-        List<Long> currentIds = new ArrayList<>();
-        try (PreparedStatement stmt = connection.prepareStatement(sql);
-                ResultSet rs = stmt.executeQuery()) {
-            while (rs.next()) {
-                currentIds.add(rs.getLong(pkCol));
+        String sql =
+                String.format("SELECT %s FROM %s", quoteIdentifier(pkCol), qualifiedTable(tbl));
+        Set<Object> currentIds = new HashSet<>();
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setFetchSize(batchSize);
+            try (ResultSet rs = stmt.executeQuery()) {
+                while (rs.next()) {
+                    currentIds.add(readPrimaryKey(rs, pkCol));
+                }
             }
         }
         List<Object> deletedIds = new ArrayList<>();
@@ -330,8 +507,10 @@ public class ChangeDataPoller {
     /** Comprehensive poll for all change types across all tables. */
     public List<ChangeEvent<RowData>> pollAllChanges() throws SQLException {
         List<ChangeEvent<RowData>> allEvents = new ArrayList<>();
-        allEvents.addAll(pollNewInserts());
+        // Poll timestamp-based changes first. If that query discovers a new row, it advances the
+        // ID watermark before insert polling and prevents a duplicate INSERT in the same cycle.
         allEvents.addAll(pollUpdates());
+        allEvents.addAll(pollNewInserts());
         allEvents.addAll(pollDeletes());
         return allEvents;
     }
@@ -348,32 +527,242 @@ public class ChangeDataPoller {
         snapshot.clear();
         String columns = getTableColumns(tbl);
         String pkCol = getPrimaryKeyColumn(tbl);
-        long maxId = 0;
+        Object maxKey = null;
+        Object maxUpdatedAtKey = null;
+        Timestamp maxUpdatedAt = new Timestamp(0);
+        String updatedAtColumn = findColumnName(tbl, "updated_at");
+        boolean tracksUpdates = updatedAtColumn != null;
 
-        String sql = String.format("SELECT %s FROM %s.%s", columns, schema, tbl);
-        try (PreparedStatement stmt = connection.prepareStatement(sql);
-                ResultSet rs = stmt.executeQuery()) {
-            ResultSetMetaData meta = rs.getMetaData();
-            while (rs.next()) {
-                long id = rs.getLong(pkCol);
-                RowData row = convertToRowDataDynamic(rs, meta);
-                snapshot.put(id, row);
-                if (id > maxId) {
-                    maxId = id;
+        String sql =
+                String.format(
+                        "SELECT %s FROM %s ORDER BY %s",
+                        columns, qualifiedTable(tbl), quoteIdentifier(pkCol));
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setFetchSize(batchSize);
+            try (ResultSet rs = stmt.executeQuery()) {
+                ResultSetMetaData meta = rs.getMetaData();
+                while (rs.next()) {
+                    Object key = readPrimaryKey(rs, pkCol);
+                    RowData row = convertToRowDataDynamic(rs, meta);
+                    snapshot.put(key, row);
+                    maxKey = key;
+                    if (tracksUpdates) {
+                        Timestamp updatedAt = rs.getTimestamp(updatedAtColumn);
+                        if (updatedAt != null && updatedAt.after(maxUpdatedAt)) {
+                            maxUpdatedAt = updatedAt;
+                            maxUpdatedAtKey = key;
+                        } else if (updatedAt != null && updatedAt.equals(maxUpdatedAt)) {
+                            // Rows are ordered by PK, so the last key at this timestamp is the
+                            // correct secondary cursor for the next page.
+                            maxUpdatedAtKey = key;
+                        }
+                    }
                 }
             }
         }
-        // Only update lastPolledId if we actually loaded rows;
-        // preserve existing value for empty tables (backward compatible)
-        if (snapshot.size() > 0 || lastPolledIds.get(tbl) == 0L) {
-            lastPolledIds.put(tbl, maxId);
+        if (maxKey != null || lastPolledKeys.get(tbl) == null) {
+            lastPolledKeys.put(tbl, maxKey);
+        }
+        if (tracksUpdates) {
+            // The JDBC snapshot was already emitted by the source. Start update polling after
+            // the newest row included in that snapshot so it is not emitted a second time.
+            lastPolledTimestamps.put(tbl, maxUpdatedAt);
+            lastPolledUpdateKeys.put(tbl, maxUpdatedAtKey);
         }
         LOG.info(
-                "Loaded snapshot for {}.{}: {} rows, lastId={}",
+                "Loaded snapshot for {}.{}: {} rows, lastKey={}",
                 schema,
                 tbl,
                 snapshot.size(),
-                lastPolledIds.get(tbl));
+                lastPolledKeys.get(tbl));
+    }
+
+    private Object readPrimaryKey(ResultSet rs, String pkCol) throws SQLException {
+        Object key = rs.getObject(pkCol);
+        if (key == null && !rs.wasNull()) {
+            // Some older/mocked JDBC result sets do not implement getObject(String) correctly.
+            long numericKey = rs.getLong(pkCol);
+            if (!rs.wasNull()) {
+                key = numericKey;
+            }
+        }
+        if (key == null) {
+            throw new SQLException("Primary key " + pkCol + " returned null");
+        }
+        if (!(key instanceof Serializable)) {
+            key = key.toString();
+        }
+        return key;
+    }
+
+    /** Serialize polling cursors and delete-detection rows for Flink operator state. */
+    byte[] serializeState() throws IOException {
+        PollingState state = new PollingState();
+        state.lastPolledKeys.putAll(lastPolledKeys);
+        for (Map.Entry<String, Timestamp> entry : lastPolledTimestamps.entrySet()) {
+            state.lastPolledTimestamps.put(entry.getKey(), entry.getValue().getTime());
+        }
+        state.lastPolledUpdateKeys.putAll(lastPolledUpdateKeys);
+        for (Map.Entry<String, Map<Object, RowData>> tableEntry : snapshots.entrySet()) {
+            Map<Object, StoredRow> rows = new HashMap<>();
+            for (Map.Entry<Object, RowData> rowEntry : tableEntry.getValue().entrySet()) {
+                rows.put(rowEntry.getKey(), StoredRow.from(rowEntry.getValue()));
+            }
+            state.snapshots.put(tableEntry.getKey(), rows);
+        }
+
+        try (ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+                ObjectOutputStream output = new ObjectOutputStream(bytes)) {
+            output.writeObject(state);
+            output.flush();
+            return bytes.toByteArray();
+        }
+    }
+
+    /** Restore polling state before the streaming loop starts. */
+    void restoreState(byte[] serializedState) throws IOException {
+        if (serializedState == null || serializedState.length == 0) {
+            return;
+        }
+        PollingState state;
+        try (ObjectInputStream input =
+                new ObjectInputStream(new ByteArrayInputStream(serializedState))) {
+            Object value = input.readObject();
+            if (!(value instanceof PollingState)) {
+                throw new IOException("Unexpected polling state type: " + value.getClass());
+            }
+            state = (PollingState) value;
+        } catch (ClassNotFoundException e) {
+            throw new IOException("Could not deserialize polling state", e);
+        }
+
+        lastPolledKeys.clear();
+        lastPolledKeys.putAll(state.lastPolledKeys);
+        lastPolledTimestamps.clear();
+        for (String tbl : tableNames) {
+            Long timestamp = state.lastPolledTimestamps.get(tbl);
+            lastPolledTimestamps.put(tbl, new Timestamp(timestamp == null ? 0L : timestamp));
+        }
+        lastPolledUpdateKeys.clear();
+        lastPolledUpdateKeys.putAll(state.lastPolledUpdateKeys);
+        snapshots.clear();
+        for (String tbl : tableNames) {
+            Map<Object, RowData> rows = new HashMap<>();
+            Map<Object, StoredRow> storedRows = state.snapshots.get(tbl);
+            if (storedRows != null) {
+                for (Map.Entry<Object, StoredRow> entry : storedRows.entrySet()) {
+                    rows.put(entry.getKey(), entry.getValue().toRowData());
+                }
+            }
+            snapshots.put(tbl, rows);
+            lastPolledKeys.putIfAbsent(tbl, null);
+            lastPolledUpdateKeys.putIfAbsent(tbl, null);
+        }
+    }
+
+    private static final class PollingState implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final Map<String, Object> lastPolledKeys = new HashMap<>();
+        private final Map<String, Long> lastPolledTimestamps = new HashMap<>();
+        private final Map<String, Object> lastPolledUpdateKeys = new HashMap<>();
+        private final Map<String, Map<Object, StoredRow>> snapshots = new HashMap<>();
+    }
+
+    private static final class StoredRow implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private final byte rowKind;
+        private final List<StoredValue> fields;
+
+        private StoredRow(byte rowKind, List<StoredValue> fields) {
+            this.rowKind = rowKind;
+            this.fields = fields;
+        }
+
+        private static StoredRow from(RowData row) throws IOException {
+            if (!(row instanceof GenericRowData)) {
+                throw new IOException(
+                        "Polling state only supports GenericRowData, found "
+                                + row.getClass().getName());
+            }
+            GenericRowData genericRow = (GenericRowData) row;
+            List<StoredValue> fields = new ArrayList<>(genericRow.getArity());
+            for (int i = 0; i < genericRow.getArity(); i++) {
+                fields.add(StoredValue.from(genericRow.getField(i)));
+            }
+            return new StoredRow(row.getRowKind().toByteValue(), fields);
+        }
+
+        private RowData toRowData() {
+            GenericRowData row = new GenericRowData(RowKind.fromByteValue(rowKind), fields.size());
+            for (int i = 0; i < fields.size(); i++) {
+                row.setField(i, fields.get(i).toValue());
+            }
+            return row;
+        }
+    }
+
+    private static final class StoredValue implements Serializable {
+        private static final long serialVersionUID = 1L;
+
+        private enum Kind {
+            NULL,
+            STRING,
+            DECIMAL,
+            TIMESTAMP,
+            OBJECT
+        }
+
+        private final Kind kind;
+        private final Serializable value;
+        private final int precision;
+        private final int scale;
+
+        private StoredValue(Kind kind, Serializable value, int precision, int scale) {
+            this.kind = kind;
+            this.value = value;
+            this.precision = precision;
+            this.scale = scale;
+        }
+
+        private static StoredValue from(Object value) {
+            if (value == null) {
+                return new StoredValue(Kind.NULL, null, 0, 0);
+            }
+            if (value instanceof StringData) {
+                return new StoredValue(Kind.STRING, value.toString(), 0, 0);
+            }
+            if (value instanceof DecimalData) {
+                DecimalData decimal = (DecimalData) value;
+                return new StoredValue(
+                        Kind.DECIMAL, decimal.toBigDecimal(), decimal.precision(), decimal.scale());
+            }
+            if (value instanceof TimestampData) {
+                TimestampData timestamp = (TimestampData) value;
+                return new StoredValue(Kind.TIMESTAMP, timestamp.toTimestamp(), 0, 0);
+            }
+            Serializable serializable =
+                    value instanceof Serializable ? (Serializable) value : value.toString();
+            return new StoredValue(Kind.OBJECT, serializable, 0, 0);
+        }
+
+        private Object toValue() {
+            switch (kind) {
+                case NULL:
+                    return null;
+                case STRING:
+                    return StringData.fromString((String) value);
+                case DECIMAL:
+                    return DecimalData.fromBigDecimal(
+                            (java.math.BigDecimal) value, precision, scale);
+                case TIMESTAMP:
+                    return TimestampData.fromTimestamp((Timestamp) value);
+                case OBJECT:
+                default:
+                    return value;
+            }
+        }
     }
 
     // ---- JSON output helpers ----
@@ -381,46 +770,126 @@ public class ChangeDataPoller {
     private RowData convertToJsonRow(
             String tbl, String op, RowData oldRow, ResultSet rs, ResultSetMetaData meta)
             throws SQLException {
-        StringBuilder sb = new StringBuilder(256);
-        sb.append("{\"table\":\"").append(escapeJson(tbl)).append('"');
-        sb.append(",\"schema\":\"").append(escapeJson(schema)).append('"');
-        sb.append(",\"op\":\"").append(op).append('"');
-        // before
-        if (oldRow != null) {
-            sb.append(",\"before\":");
-            appendRowDataAsJson(sb, oldRow, meta);
+        String json;
+        if ("canal".equalsIgnoreCase(outputJsonFormat)) {
+            json = buildCanalJson(tbl, op, oldRow, rs, meta);
+        } else if ("he".equalsIgnoreCase(outputJsonFormat)) {
+            json = buildCustomJson(tbl, op, oldRow, rs, meta);
         } else {
-            sb.append(",\"before\":{}");
+            json = buildDebeziumJson(tbl, op, oldRow, rs, meta);
         }
-        // after
-        sb.append(",\"after\":");
-        appendResultSetAsJson(sb, rs, meta);
-        sb.append('}');
-
         GenericRowData row = new GenericRowData(1);
-        row.setField(0, StringData.fromString(sb.toString()));
+        row.setField(0, StringData.fromString(json));
         return row;
     }
 
-    private RowData convertToJsonRowForDelete(String tbl, RowData oldRow) {
-        StringBuilder sb = new StringBuilder(256);
-        sb.append("{\"table\":\"").append(escapeJson(tbl)).append('"');
-        sb.append(",\"schema\":\"").append(escapeJson(schema)).append('"');
-        sb.append(",\"op\":\"DELETE\"");
-        sb.append(",\"before\":");
-        // For delete, we don't have ResultSetMetaData here; serialize what we have
-        if (oldRow instanceof GenericRowData) {
-            GenericRowData gd = (GenericRowData) oldRow;
-            sb.append("{\"row\":\"").append(gd.toString()).append("\"}");
+    private RowData convertToJsonRowForDelete(String tbl, RowData oldRow) throws SQLException {
+        String json;
+        if ("canal".equalsIgnoreCase(outputJsonFormat)) {
+            json = buildCanalJson(tbl, "DELETE", oldRow, null, null);
+        } else if ("he".equalsIgnoreCase(outputJsonFormat)) {
+            json = buildCustomJson(tbl, "DELETE", oldRow, null, null);
         } else {
-            sb.append("{}");
+            json = buildDebeziumJson(tbl, "DELETE", oldRow, null, null);
         }
-        sb.append(",\"after\":{}}");
-
         GenericRowData row = new GenericRowData(1);
-        row.setField(0, StringData.fromString(sb.toString()));
+        row.setField(0, StringData.fromString(json));
         row.setRowKind(RowKind.DELETE);
         return row;
+    }
+
+    private String buildDebeziumJson(
+            String tbl, String operation, RowData oldRow, ResultSet rs, ResultSetMetaData meta)
+            throws SQLException {
+        long now = System.currentTimeMillis();
+        StringBuilder sb = new StringBuilder(512);
+        sb.append("{\"before\":");
+        appendBeforeJson(sb, tbl, oldRow);
+        sb.append(",\"after\":");
+        appendAfterJson(sb, rs, meta);
+        sb.append(",\"source\":{\"connector\":\"gaussdb\"");
+        sb.append(",\"db\":\"").append(escapeJson(database)).append('"');
+        sb.append(",\"schema\":\"").append(escapeJson(schema)).append('"');
+        sb.append(",\"table\":\"").append(escapeJson(tbl)).append('"');
+        sb.append(",\"ts_ms\":").append(now).append(",\"snapshot\":false}");
+        sb.append(",\"op\":\"").append(debeziumOperation(operation)).append('"');
+        sb.append(",\"ts_ms\":").append(now).append(",\"transaction\":null}");
+        return sb.toString();
+    }
+
+    private String buildCanalJson(
+            String tbl, String operation, RowData oldRow, ResultSet rs, ResultSetMetaData meta)
+            throws SQLException {
+        long now = System.currentTimeMillis();
+        StringBuilder sb = new StringBuilder(512);
+        sb.append("{\"data\":");
+        appendAfterJson(sb, rs, meta);
+        sb.append(",\"old\":");
+        appendBeforeJson(sb, tbl, oldRow);
+        sb.append(",\"database\":\"").append(escapeJson(database)).append('"');
+        sb.append(",\"table\":\"").append(escapeJson(tbl)).append('"');
+        sb.append(",\"type\":\"").append(operation).append('"');
+        appendPrimaryKeyNames(sb, tbl);
+        sb.append(",\"es\":").append(now).append(",\"ts\":").append(now);
+        sb.append(",\"isDdl\":false,\"sqlType\":{},\"mysqlType\":{}}");
+        return sb.toString();
+    }
+
+    private String buildCustomJson(
+            String tbl, String operation, RowData oldRow, ResultSet rs, ResultSetMetaData meta)
+            throws SQLException {
+        long now = System.currentTimeMillis();
+        String pkCol = getPrimaryKeyColumn(tbl);
+        StringBuilder sb = new StringBuilder(512);
+        sb.append("{\"database\":\"").append(escapeJson(database)).append('"');
+        sb.append(",\"table\":\"").append(escapeJson(tbl)).append('"');
+        sb.append(",\"optType\":\"").append(operation).append('"');
+        appendPrimaryKeyNames(sb, tbl);
+        String pkValue = rs != null ? rs.getString(pkCol) : extractValueFromRow(tbl, oldRow, pkCol);
+        if (pkValue == null) {
+            sb.append(",\"pkValues\":null");
+        } else {
+            sb.append(",\"pkValues\":\"").append(escapeJson(pkValue)).append('"');
+        }
+        sb.append(",\"es\":").append(now).append(",\"ts\":").append(now);
+        sb.append(",\"data\":");
+        appendAfterJson(sb, rs, meta);
+        sb.append(",\"old\":");
+        appendBeforeJson(sb, tbl, oldRow);
+        sb.append('}');
+        return sb.toString();
+    }
+
+    private void appendPrimaryKeyNames(StringBuilder sb, String tbl) throws SQLException {
+        String pkCol = getPrimaryKeyColumn(tbl);
+        sb.append(",\"pkNames\":[\"").append(escapeJson(pkCol)).append("\"]");
+    }
+
+    private String debeziumOperation(String operation) {
+        if ("INSERT".equals(operation)) {
+            return "c";
+        }
+        if ("DELETE".equals(operation)) {
+            return "d";
+        }
+        return "u";
+    }
+
+    private void appendBeforeJson(StringBuilder sb, String tbl, RowData oldRow) {
+        if (oldRow == null) {
+            sb.append("null");
+        } else {
+            appendRowDataAsJson(sb, tbl, oldRow);
+        }
+    }
+
+    private void appendAfterJson(StringBuilder sb, ResultSet rs, ResultSetMetaData meta)
+            throws SQLException {
+        if (rs == null) {
+            sb.append("null");
+        } else {
+            appendResultSetAsJson(sb, rs, meta);
+        }
     }
 
     private void appendResultSetAsJson(StringBuilder sb, ResultSet rs, ResultSetMetaData meta)
@@ -442,19 +911,19 @@ public class ChangeDataPoller {
         sb.append('}');
     }
 
-    private void appendRowDataAsJson(StringBuilder sb, RowData row, ResultSetMetaData meta)
-            throws SQLException {
+    private void appendRowDataAsJson(StringBuilder sb, String tbl, RowData row) {
         if (!(row instanceof GenericRowData)) {
             sb.append("{}");
             return;
         }
         GenericRowData gd = (GenericRowData) row;
+        List<String> columns = cachedColumnNames.get(tbl);
         sb.append('{');
-        for (int i = 0; i < gd.getArity() && i < meta.getColumnCount(); i++) {
+        for (int i = 0; i < gd.getArity() && i < columns.size(); i++) {
             if (i > 0) {
                 sb.append(',');
             }
-            String colName = meta.getColumnName(i + 1);
+            String colName = columns.get(i);
             sb.append('"').append(escapeJson(colName)).append("\":");
             Object val = gd.getField(i);
             if (val == null) {
@@ -466,6 +935,21 @@ public class ChangeDataPoller {
             }
         }
         sb.append('}');
+    }
+
+    private String extractValueFromRow(String tbl, RowData row, String columnName) {
+        if (!(row instanceof GenericRowData)) {
+            return null;
+        }
+        List<String> columns = cachedColumnNames.get(tbl);
+        GenericRowData genericRow = (GenericRowData) row;
+        for (int i = 0; i < columns.size() && i < genericRow.getArity(); i++) {
+            if (columnName.equalsIgnoreCase(columns.get(i))) {
+                Object value = genericRow.getField(i);
+                return value == null ? null : String.valueOf(value);
+            }
+        }
+        return null;
     }
 
     private String escapeJson(String s) {

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunction.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunction.java
@@ -134,6 +134,8 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     private final Integer replicationPort;
     /** Output format: "raw" (RowData, default) or "json" (single STRING column with JSON). */
     private final String outputFormat;
+    /** JSON sub-format when output.format=json: "debezium" (default), "canal", or "haier". */
+    private final String outputJsonFormat;
 
     /** Compiled regex pattern for table-name matching. Null means exact match on tableName. */
     private transient Pattern tablePattern;
@@ -180,6 +182,7 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         this.sslMode = builder.sslMode;
         this.replicationPort = builder.replicationPort;
         this.outputFormat = builder.outputFormat;
+        this.outputJsonFormat = builder.outputJsonFormat;
     }
 
     @Override
@@ -1064,15 +1067,132 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
      * @return RowData with a single StringData field containing the JSON string
      */
     private RowData convertWalChangeToJson(WalChange change) {
+        String json;
+        if ("canal".equalsIgnoreCase(outputJsonFormat)) {
+            json = buildCanalJson(change);
+        } else if ("haier".equalsIgnoreCase(outputJsonFormat)) {
+            json = buildHaierJson(change);
+        } else {
+            json = buildDebeziumJson(change);
+        }
+        GenericRowData row = new GenericRowData(1);
+        row.setField(0, StringData.fromString(json));
+        if (change.getType() == WalChange.ChangeType.DELETE) {
+            row.setRowKind(RowKind.DELETE);
+        }
+        return row;
+    }
+
+    /** Build Debezium standard JSON format. */
+    private String buildDebeziumJson(WalChange change) {
+        StringBuilder sb = new StringBuilder(512);
+        sb.append('{');
+        // before
+        sb.append("\"before\":");
+        appendColumnsAsJson(sb, change.getBeforeColumns());
+        // after
+        sb.append(",\"after\":");
+        appendColumnsAsJson(sb, change.getAfterColumns());
+        // source
+        sb.append(",\"source\":{");
+        sb.append("\"connector\":\"gaussdb\"");
+        sb.append(",\"db\":\"").append(escapeJson(database)).append('"');
+        sb.append(",\"schema\":\"").append(escapeJson(change.getSchema())).append('"');
+        sb.append(",\"table\":\"").append(escapeJson(change.getTable())).append('"');
+        if (change.getLsn() != null) {
+            sb.append(",\"lsn\":\"").append(escapeJson(change.getLsn())).append('"');
+        }
+        long now = System.currentTimeMillis();
+        sb.append(",\"ts_ms\":").append(now);
+        sb.append(",\"snapshot\":false");
+        sb.append('}');
+        // op
+        String op;
+        switch (change.getType()) {
+            case INSERT:
+                op = "c";
+                break;
+            case UPDATE:
+                op = "u";
+                break;
+            case DELETE:
+                op = "d";
+                break;
+            default:
+                op = "u";
+        }
+        sb.append(",\"op\":\"").append(op).append('"');
+        // ts_ms
+        sb.append(",\"ts_ms\":").append(now);
+        sb.append(",\"transaction\":null");
+        sb.append('}');
+        return sb.toString();
+    }
+
+    /** Build Canal standard JSON format. */
+    private String buildCanalJson(WalChange change) {
+        StringBuilder sb = new StringBuilder(512);
+        sb.append('{');
+        // data (after columns for INSERT/UPDATE, null for DELETE)
+        if (change.getType() == WalChange.ChangeType.DELETE) {
+            sb.append("\"data\":null");
+        } else {
+            sb.append("\"data\":");
+            appendColumnsAsJson(sb, change.getAfterColumns());
+        }
+        // old (before columns for UPDATE/DELETE, null for INSERT)
+        if (change.getType() == WalChange.ChangeType.INSERT) {
+            sb.append(",\"old\":null");
+        } else {
+            List<WalChange.ColumnValue> before = change.getBeforeColumns();
+            if (before == null || before.isEmpty()) {
+                sb.append(",\"old\":null");
+            } else {
+                sb.append(",\"old\":");
+                appendColumnsAsJson(sb, before);
+            }
+        }
+        // database
+        sb.append(",\"database\":\"").append(escapeJson(database)).append('"');
+        // table
+        sb.append(",\"table\":\"").append(escapeJson(change.getTable())).append('"');
+        // type
+        sb.append(",\"type\":\"").append(change.getType().name()).append('"');
+        // pkNames
+        String pkCol = null;
+        if (cachedPkByTable != null) {
+            pkCol = cachedPkByTable.get(change.getTable());
+        }
+        if (pkCol != null) {
+            sb.append(",\"pkNames\":[\"").append(escapeJson(pkCol)).append("\"]");
+        } else {
+            sb.append(",\"pkNames\":[]");
+        }
+        // es
+        long now = System.currentTimeMillis();
+        sb.append(",\"es\":").append(now);
+        // ts
+        sb.append(",\"ts\":").append(now);
+        // isDdl
+        sb.append(",\"isDdl\":false");
+        // sqlType (empty for now)
+        sb.append(",\"sqlType\":{}");
+        // mysqlType (empty for now)
+        sb.append(",\"mysqlType\":{}");
+        sb.append('}');
+        return sb.toString();
+    }
+
+    /** Build Haier customized Canal JSON format. */
+    private String buildHaierJson(WalChange change) {
         StringBuilder sb = new StringBuilder(512);
         sb.append('{');
         // database
         sb.append("\"database\":\"").append(escapeJson(database)).append('"');
         // table
         sb.append(",\"table\":\"").append(escapeJson(change.getTable())).append('"');
-        // optType
-        String optType = change.getType().name();
-        sb.append(",\"optType\":\"").append(optType).append('"');
+        // optType (haier uses optType instead of type)
+        sb.append(",\"optType\":\"").append(change.getType().name()).append('"');
         // pkNames + pkValues
         String tbl = change.getTable();
         String pkCol = null;
@@ -1081,7 +1201,6 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         }
         if (pkCol != null) {
             sb.append(",\"pkNames\":[\"").append(escapeJson(pkCol)).append("\"]");
-            // Find PK value from the change columns
             String pkVal = extractPkValue(change, pkCol);
             if (pkVal != null) {
                 sb.append(",\"pkValues\":\"").append(escapeJson(pkVal)).append('"');
@@ -1092,10 +1211,10 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             sb.append(",\"pkNames\":[]");
             sb.append(",\"pkValues\":null");
         }
-        // es (event source timestamp = change LSN-based or system time)
+        // es
         long now = System.currentTimeMillis();
         sb.append(",\"es\":").append(now);
-        // ts (processing timestamp)
+        // ts
         sb.append(",\"ts\":").append(now);
         // data (after columns for INSERT/UPDATE, null for DELETE)
         if (change.getType() == WalChange.ChangeType.DELETE) {
@@ -1116,18 +1235,12 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                 appendColumnsAsJson(sb, before);
             }
         }
-        // lsn (for diagnostics, not in Haier format but useful)
+        // lsn (diagnostic)
         if (change.getLsn() != null) {
             sb.append(",\"lsn\":\"").append(escapeJson(change.getLsn())).append('"');
         }
         sb.append('}');
-
-        GenericRowData row = new GenericRowData(1);
-        row.setField(0, StringData.fromString(sb.toString()));
-        if (change.getType() == WalChange.ChangeType.DELETE) {
-            row.setRowKind(RowKind.DELETE);
-        }
-        return row;
+        return sb.toString();
     }
 
     /** Extract the primary key value from a WalChange. */
@@ -1214,62 +1327,134 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     private RowData convertSnapshotRow(ResultSet rs, ResultSetMetaData meta, String tbl)
             throws SQLException {
         if ("json".equalsIgnoreCase(outputFormat)) {
-            String pkCol = null;
-            if (cachedPkByTable != null) {
-                pkCol = cachedPkByTable.get(tbl);
-            }
-            long now = System.currentTimeMillis();
-            StringBuilder sb = new StringBuilder(512);
-            sb.append('{');
-            sb.append("\"database\":\"").append(escapeJson(database)).append('"');
-            sb.append(",\"table\":\"").append(escapeJson(tbl)).append('"');
-            sb.append(",\"optType\":\"INSERT\"");
-            // pkNames + pkValues
-            if (pkCol != null) {
-                sb.append(",\"pkNames\":[\"").append(escapeJson(pkCol)).append("\"]");
-                String pkVal = null;
-                try {
-                    pkVal = rs.getString(pkCol);
-                } catch (SQLException e) {
-                    // PK column not in result set
-                }
-                if (pkVal != null && !rs.wasNull()) {
-                    sb.append(",\"pkValues\":\"").append(escapeJson(pkVal)).append('"');
-                } else {
-                    sb.append(",\"pkValues\":null");
-                }
+            String json;
+            if ("canal".equalsIgnoreCase(outputJsonFormat)) {
+                json = buildCanalSnapshotJson(rs, meta, tbl);
+            } else if ("haier".equalsIgnoreCase(outputJsonFormat)) {
+                json = buildHaierSnapshotJson(rs, meta, tbl);
             } else {
-                sb.append(",\"pkNames\":[]");
-                sb.append(",\"pkValues\":null");
+                json = buildDebeziumSnapshotJson(rs, meta, tbl);
             }
-            sb.append(",\"es\":").append(now);
-            sb.append(",\"ts\":").append(now);
-            // data = all columns
-            sb.append(",\"data\":");
-            sb.append('{');
-            for (int i = 1; i <= meta.getColumnCount(); i++) {
-                if (i > 1) {
-                    sb.append(',');
-                }
-                String colName = meta.getColumnName(i);
-                sb.append('"').append(escapeJson(colName)).append("\":");
-                String val = rs.getString(i);
-                if (rs.wasNull()) {
-                    sb.append("null");
-                } else {
-                    sb.append('"').append(escapeJson(val)).append('"');
-                }
-            }
-            sb.append('}');
-            // old = null for snapshot (INSERT)
-            sb.append(",\"old\":null");
-            sb.append('}');
             GenericRowData row = new GenericRowData(1);
-            row.setField(0, StringData.fromString(sb.toString()));
+            row.setField(0, StringData.fromString(json));
             return row;
         } else {
             return convertToRowDataDynamic(rs, meta);
         }
+    }
+
+    /** Build Debezium JSON for snapshot row (op="c" for create/read). */
+    private String buildDebeziumSnapshotJson(ResultSet rs, ResultSetMetaData meta, String tbl)
+            throws SQLException {
+        StringBuilder sb = new StringBuilder(512);
+        sb.append('{');
+        sb.append("\"before\":null");
+        sb.append(",\"after\":");
+        appendResultSetAsJson(sb, rs, meta);
+        sb.append(",\"source\":{");
+        sb.append("\"connector\":\"gaussdb\"");
+        sb.append(",\"db\":\"").append(escapeJson(database)).append('"');
+        sb.append(",\"schema\":\"").append(escapeJson(schema)).append('"');
+        sb.append(",\"table\":\"").append(escapeJson(tbl)).append('"');
+        long now = System.currentTimeMillis();
+        sb.append(",\"ts_ms\":").append(now);
+        sb.append(",\"snapshot\":true");
+        sb.append('}');
+        sb.append(",\"op\":\"c\"");
+        sb.append(",\"ts_ms\":").append(now);
+        sb.append(",\"transaction\":null");
+        sb.append('}');
+        return sb.toString();
+    }
+
+    /** Build Canal JSON for snapshot row (type=INSERT). */
+    private String buildCanalSnapshotJson(ResultSet rs, ResultSetMetaData meta, String tbl)
+            throws SQLException {
+        StringBuilder sb = new StringBuilder(512);
+        sb.append('{');
+        sb.append("\"data\":");
+        appendResultSetAsJson(sb, rs, meta);
+        sb.append(",\"old\":null");
+        sb.append(",\"database\":\"").append(escapeJson(database)).append('"');
+        sb.append(",\"table\":\"").append(escapeJson(tbl)).append('"');
+        sb.append(",\"type\":\"INSERT\"");
+        // pkNames
+        String pkCol = null;
+        if (cachedPkByTable != null) {
+            pkCol = cachedPkByTable.get(tbl);
+        }
+        if (pkCol != null) {
+            sb.append(",\"pkNames\":[\"").append(escapeJson(pkCol)).append("\"]");
+        } else {
+            sb.append(",\"pkNames\":[]");
+        }
+        long now = System.currentTimeMillis();
+        sb.append(",\"es\":").append(now);
+        sb.append(",\"ts\":").append(now);
+        sb.append(",\"isDdl\":false");
+        sb.append(",\"sqlType\":{}");
+        sb.append(",\"mysqlType\":{}");
+        sb.append('}');
+        return sb.toString();
+    }
+
+    /** Build Haier JSON for snapshot row (optType=INSERT). */
+    private String buildHaierSnapshotJson(ResultSet rs, ResultSetMetaData meta, String tbl)
+            throws SQLException {
+        String pkCol = null;
+        if (cachedPkByTable != null) {
+            pkCol = cachedPkByTable.get(tbl);
+        }
+        long now = System.currentTimeMillis();
+        StringBuilder sb = new StringBuilder(512);
+        sb.append('{');
+        sb.append("\"database\":\"").append(escapeJson(database)).append('"');
+        sb.append(",\"table\":\"").append(escapeJson(tbl)).append('"');
+        sb.append(",\"optType\":\"INSERT\"");
+        if (pkCol != null) {
+            sb.append(",\"pkNames\":[\"").append(escapeJson(pkCol)).append("\"]");
+            String pkVal = null;
+            try {
+                pkVal = rs.getString(pkCol);
+            } catch (SQLException e) {
+                // PK column not in result set
+            }
+            if (pkVal != null && !rs.wasNull()) {
+                sb.append(",\"pkValues\":\"").append(escapeJson(pkVal)).append('"');
+            } else {
+                sb.append(",\"pkValues\":null");
+            }
+        } else {
+            sb.append(",\"pkNames\":[]");
+            sb.append(",\"pkValues\":null");
+        }
+        sb.append(",\"es\":").append(now);
+        sb.append(",\"ts\":").append(now);
+        sb.append(",\"data\":");
+        appendResultSetAsJson(sb, rs, meta);
+        sb.append(",\"old\":null");
+        sb.append('}');
+        return sb.toString();
+    }
+
+    /** Append ResultSet columns as a JSON object. */
+    private void appendResultSetAsJson(StringBuilder sb, ResultSet rs, ResultSetMetaData meta)
+            throws SQLException {
+        sb.append('{');
+        for (int i = 1; i <= meta.getColumnCount(); i++) {
+            if (i > 1) {
+                sb.append(',');
+            }
+            String colName = meta.getColumnName(i);
+            sb.append('"').append(escapeJson(colName)).append("\":");
+            String val = rs.getString(i);
+            if (rs.wasNull()) {
+                sb.append("null");
+            } else {
+                sb.append('"').append(escapeJson(val)).append('"');
+            }
+        }
+        sb.append('}');
     }
 
     private Object convertColumnValueByOid(int typeOid, String value) {
@@ -1413,6 +1598,7 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         private String sslMode = GaussDBCDCOptions.SSL_MODE.defaultValue();
         private Integer replicationPort;
         private String outputFormat = "raw";
+        private String outputJsonFormat = "debezium";
 
         public Builder hostname(String hostname) {
             this.hostname = hostname;
@@ -1516,6 +1702,11 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
 
         public Builder outputFormat(String outputFormat) {
             this.outputFormat = outputFormat;
+            return this;
+        }
+
+        public Builder outputJsonFormat(String outputJsonFormat) {
+            this.outputJsonFormat = outputJsonFormat;
             return this;
         }
 

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunction.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunction.java
@@ -1044,35 +1044,82 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
      * Convert a WalChange to a single-column RowData containing a JSON string. Used in
      * output.format=json mode for heterogeneous multi-table capture.
      *
-     * <p>JSON format:
+     * <p>JSON format (aligned with Haier CDC extraction structure):
      *
      * <pre>
-     * {"table":"orders","schema":"public","op":"INSERT","lsn":"0/12345678",
-     *  "before":{},"after":{"id":1,"name":"Alice","amount":100.50}}
+     * {
+     *   "database": "event_driven",
+     *   "table": "haier_cbs_order_oper",
+     *   "optType": "INSERT",
+     *   "pkNames": ["id"],
+     *   "pkValues": "722253",
+     *   "es": 1783489586878,
+     *   "ts": 1783489587143,
+     *   "data": {"id": "722253", "name": "Alice", ...},
+     *   "old": null
+     * }
      * </pre>
      *
      * @param change the WAL change event
      * @return RowData with a single StringData field containing the JSON string
      */
     private RowData convertWalChangeToJson(WalChange change) {
-        StringBuilder sb = new StringBuilder(256);
+        StringBuilder sb = new StringBuilder(512);
         sb.append('{');
+        // database
+        sb.append("\"database\":\"").append(escapeJson(database)).append('"');
         // table
-        sb.append("\"table\":\"").append(escapeJson(change.getTable())).append('"');
-        // schema
-        sb.append(",\"schema\":\"").append(escapeJson(change.getSchema())).append('"');
-        // op
-        sb.append(",\"op\":\"").append(change.getType().name()).append('"');
-        // lsn
+        sb.append(",\"table\":\"").append(escapeJson(change.getTable())).append('"');
+        // optType
+        String optType = change.getType().name();
+        sb.append(",\"optType\":\"").append(optType).append('"');
+        // pkNames + pkValues
+        String tbl = change.getTable();
+        String pkCol = null;
+        if (cachedPkByTable != null) {
+            pkCol = cachedPkByTable.get(tbl);
+        }
+        if (pkCol != null) {
+            sb.append(",\"pkNames\":[\"").append(escapeJson(pkCol)).append("\"]");
+            // Find PK value from the change columns
+            String pkVal = extractPkValue(change, pkCol);
+            if (pkVal != null) {
+                sb.append(",\"pkValues\":\"").append(escapeJson(pkVal)).append('"');
+            } else {
+                sb.append(",\"pkValues\":null");
+            }
+        } else {
+            sb.append(",\"pkNames\":[]");
+            sb.append(",\"pkValues\":null");
+        }
+        // es (event source timestamp = change LSN-based or system time)
+        long now = System.currentTimeMillis();
+        sb.append(",\"es\":").append(now);
+        // ts (processing timestamp)
+        sb.append(",\"ts\":").append(now);
+        // data (after columns for INSERT/UPDATE, null for DELETE)
+        if (change.getType() == WalChange.ChangeType.DELETE) {
+            sb.append(",\"data\":null");
+        } else {
+            sb.append(",\"data\":");
+            appendColumnsAsJson(sb, change.getAfterColumns());
+        }
+        // old (before columns for UPDATE/DELETE, null for INSERT)
+        if (change.getType() == WalChange.ChangeType.INSERT) {
+            sb.append(",\"old\":null");
+        } else {
+            List<WalChange.ColumnValue> before = change.getBeforeColumns();
+            if (before == null || before.isEmpty()) {
+                sb.append(",\"old\":null");
+            } else {
+                sb.append(",\"old\":");
+                appendColumnsAsJson(sb, before);
+            }
+        }
+        // lsn (for diagnostics, not in Haier format but useful)
         if (change.getLsn() != null) {
             sb.append(",\"lsn\":\"").append(escapeJson(change.getLsn())).append('"');
         }
-        // before (DELETE/UPDATE)
-        sb.append(",\"before\":");
-        appendColumnsAsJson(sb, change.getBeforeColumns());
-        // after (INSERT/UPDATE)
-        sb.append(",\"after\":");
-        appendColumnsAsJson(sb, change.getAfterColumns());
         sb.append('}');
 
         GenericRowData row = new GenericRowData(1);
@@ -1081,6 +1128,24 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             row.setRowKind(RowKind.DELETE);
         }
         return row;
+    }
+
+    /** Extract the primary key value from a WalChange. */
+    private String extractPkValue(WalChange change, String pkCol) {
+        // For INSERT/UPDATE, look in after columns
+        List<WalChange.ColumnValue> cols = change.getAfterColumns();
+        if (change.getType() == WalChange.ChangeType.DELETE) {
+            cols = change.getBeforeColumns();
+        }
+        if (cols == null) {
+            return null;
+        }
+        for (WalChange.ColumnValue col : cols) {
+            if (pkCol.equalsIgnoreCase(col.getColumnName()) && !col.isNull()) {
+                return col.getValue();
+            }
+        }
+        return null;
     }
 
     /** Append a list of column values as a JSON object. */
@@ -1149,13 +1214,38 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     private RowData convertSnapshotRow(ResultSet rs, ResultSetMetaData meta, String tbl)
             throws SQLException {
         if ("json".equalsIgnoreCase(outputFormat)) {
-            StringBuilder sb = new StringBuilder(256);
-            sb.append("{\"table\":\"").append(escapeJson(tbl)).append('"');
-            sb.append(",\"schema\":\"").append(escapeJson(schema)).append('"');
-            sb.append(",\"op\":\"INSERT\"");
-            sb.append(",\"before\":{}");
-            sb.append(",\"after\":");
-            // Append all columns as JSON
+            String pkCol = null;
+            if (cachedPkByTable != null) {
+                pkCol = cachedPkByTable.get(tbl);
+            }
+            long now = System.currentTimeMillis();
+            StringBuilder sb = new StringBuilder(512);
+            sb.append('{');
+            sb.append("\"database\":\"").append(escapeJson(database)).append('"');
+            sb.append(",\"table\":\"").append(escapeJson(tbl)).append('"');
+            sb.append(",\"optType\":\"INSERT\"");
+            // pkNames + pkValues
+            if (pkCol != null) {
+                sb.append(",\"pkNames\":[\"").append(escapeJson(pkCol)).append("\"]");
+                String pkVal = null;
+                try {
+                    pkVal = rs.getString(pkCol);
+                } catch (SQLException e) {
+                    // PK column not in result set
+                }
+                if (pkVal != null && !rs.wasNull()) {
+                    sb.append(",\"pkValues\":\"").append(escapeJson(pkVal)).append('"');
+                } else {
+                    sb.append(",\"pkValues\":null");
+                }
+            } else {
+                sb.append(",\"pkNames\":[]");
+                sb.append(",\"pkValues\":null");
+            }
+            sb.append(",\"es\":").append(now);
+            sb.append(",\"ts\":").append(now);
+            // data = all columns
+            sb.append(",\"data\":");
             sb.append('{');
             for (int i = 1; i <= meta.getColumnCount(); i++) {
                 if (i > 1) {
@@ -1171,6 +1261,8 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                 }
             }
             sb.append('}');
+            // old = null for snapshot (INSERT)
+            sb.append(",\"old\":null");
             sb.append('}');
             GenericRowData row = new GenericRowData(1);
             row.setField(0, StringData.fromString(sb.toString()));

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunction.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunction.java
@@ -51,7 +51,10 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.regex.Pattern;
 
 /**
  * A CDC SourceFunction implementation for GaussDB that captures change events from GaussDB WAL.
@@ -129,6 +132,11 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
      * replication. See {@link GaussDBCDCOptions#REPLICATION_PORT}.
      */
     private final Integer replicationPort;
+    /** Output format: "raw" (RowData, default) or "json" (single STRING column with JSON). */
+    private final String outputFormat;
+
+    /** Compiled regex pattern for table-name matching. Null means exact match on tableName. */
+    private transient Pattern tablePattern;
 
     // Runtime state
     private transient volatile boolean running = true;
@@ -137,9 +145,9 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     private transient ChangeDataPoller changeDataPoller;
     private transient boolean walStreamInitialized = false;
 
-    // Cached column metadata for WAL change conversion
-    private transient List<String> cachedColumnNames;
-    private transient String cachedPkColumn;
+    // Cached column metadata for WAL change conversion — supports multi-table via Map
+    private transient Map<String, List<String>> cachedColumnsByTable;
+    private transient Map<String, String> cachedPkByTable;
 
     // LSN recorded after snapshot to avoid WAL replay of already-snapshot data
     private transient String snapshotStartLsn = null;
@@ -171,6 +179,7 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         this.sendingBatch = builder.sendingBatch;
         this.sslMode = builder.sslMode;
         this.replicationPort = builder.replicationPort;
+        this.outputFormat = builder.outputFormat;
     }
 
     @Override
@@ -183,6 +192,17 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                 String.format(
                         "jdbc:gaussdb://%s:%d/%s?sslmode=%s", hostname, port, database, sslMode);
         this.connection = DriverManager.getConnection(url, username, password);
+
+        // Initialize multi-table structures
+        this.cachedColumnsByTable = new HashMap<>();
+        this.cachedPkByTable = new HashMap<>();
+
+        // Compile regex pattern if table-name contains regex metacharacters
+        if (tableName != null && tableName.matches(".*[.*+?^$\\[\\]()|\\\\].*")) {
+            tablePattern = Pattern.compile(tableName, Pattern.CASE_INSENSITIVE);
+            LOG.info(
+                    "Table-name '{}' compiled as regex pattern for multi-table capture", tableName);
+        }
 
         if (walMode) {
             this.walReplicationStream =
@@ -205,53 +225,66 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                         port);
             }
             LOG.info(
-                    "Using WAL mode with plugin={}, parallel-decode-num={}, decode-style={}",
+                    "Using WAL mode with plugin={}, parallel-decode-num={}, decode-style={}, output.format={}",
                     decodePlugin,
                     parallelDecodeNum,
-                    decodeStyle);
+                    decodeStyle,
+                    outputFormat);
         } else {
-            String pkColumn = getPrimaryKeyColumn();
-            this.changeDataPoller = new ChangeDataPoller(connection, schema, tableName, pkColumn);
-            LOG.info("Using polling-based CDC mode, primary key column: {}", pkColumn);
+            // Polling mode: discover matching tables and create poller for each
+            List<String> matchedTables = discoverMatchingTables();
+            if (matchedTables.isEmpty()) {
+                throw new SQLException(
+                        "No tables found matching pattern '" + tableName + "' in schema " + schema);
+            }
+            LOG.info("Discovered {} matching table(s): {}", matchedTables.size(), matchedTables);
+            this.changeDataPoller =
+                    new ChangeDataPoller(connection, schema, matchedTables, outputFormat);
+            LOG.info("Using polling-based CDC mode for {} table(s)", matchedTables.size());
         }
 
         // Cache column names for WAL change conversion (needed because DELETE/UPDATE
-        // may only send a subset of columns, but Flink expects full-row arity)
-        try {
-            java.sql.DatabaseMetaData meta = connection.getMetaData();
-            java.util.List<String> colNames = new java.util.ArrayList<>();
-            try (java.sql.ResultSet rs = meta.getColumns(null, schema, tableName, null)) {
-                while (rs.next()) {
-                    colNames.add(rs.getString("COLUMN_NAME"));
+        // may only send a subset of columns, but Flink expects full-row arity).
+        // In multi-table mode, cache columns for each discovered table.
+        if (walMode) {
+            try {
+                List<String> tablesToCache = discoverMatchingTables();
+                for (String tbl : tablesToCache) {
+                    cacheTableColumns(tbl);
+                    // Pre-cache PK for each table
+                    getPrimaryKeyColumn(tbl);
                 }
+                LOG.info("Cached column metadata for {} table(s)", tablesToCache.size());
+            } catch (Exception e) {
+                LOG.warn("Failed to cache column metadata for some tables: {}", e.getMessage());
             }
-            this.cachedColumnNames = colNames;
-            LOG.info(
-                    "Cached {} columns for table {}.{}: {}",
-                    colNames.size(),
-                    schema,
-                    tableName,
-                    colNames);
-        } catch (Exception e) {
-            LOG.warn("Failed to cache column names for {}.{}", schema, tableName, e);
         }
 
         LOG.info(
-                "GaussDB CDC SourceFunction opened: {}:{}/{}.{}",
+                "GaussDB CDC SourceFunction opened: {}:{}/{}.{} (output.format={})",
                 hostname,
                 port,
                 database,
                 schema,
-                tableName);
+                tableName,
+                outputFormat);
     }
 
     @Override
     public void run(SourceContext<RowData> ctx) throws Exception {
         // Phase 1: Snapshot - read initial table data
         if (snapshotMode) {
-            LOG.info("Starting snapshot phase for {}.{}", schema, tableName);
-            readSnapshot(ctx);
-            LOG.info("Snapshot phase completed for {}.{}", schema, tableName);
+            List<String> tables = discoverMatchingTables();
+            LOG.info(
+                    "Starting snapshot phase for {} table(s) matching '{}': {}",
+                    tables.size(),
+                    tableName,
+                    tables);
+            for (String tbl : tables) {
+                readSnapshot(ctx, tbl);
+                LOG.info("Snapshot completed for table {}.{}", schema, tbl);
+            }
+            LOG.info("Snapshot phase completed for all {} table(s)", tables.size());
         }
 
         // Phase 2: Streaming - continuously capture changes
@@ -270,7 +303,7 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     }
 
     /** Phase 1: Read initial snapshot via JDBC SELECT with parallel split support. */
-    private void readSnapshot(SourceContext<RowData> ctx) throws SQLException {
+    private void readSnapshot(SourceContext<RowData> ctx, String tbl) throws SQLException {
         // Record WAL position BEFORE snapshot for diagnostics.
         if (walMode) {
             String preSnapshotLsn = getSlotConfirmedFlush();
@@ -279,12 +312,12 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
 
         int subtaskIndex = getRuntimeContext().getIndexOfThisSubtask();
         int numSubtasks = getRuntimeContext().getNumberOfParallelSubtasks();
-        String columns = getTableColumns();
-        String pkColumn = getPrimaryKeyColumn();
+        String columns = getTableColumns(tbl);
+        String pkColumn = getPrimaryKeyColumn(tbl);
 
         if (numSubtasks > 1) {
             // Parallel snapshot: each subtask reads a different id range
-            long[] range = getIdRange();
+            long[] range = getIdRange(tbl, pkColumn);
             long minId = range[0];
             long maxId = range[1];
             long totalRange = maxId - minId + 1;
@@ -299,16 +332,18 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             }
 
             LOG.info(
-                    "Parallel snapshot: subtask {}/{}, id range [{}, {}]",
+                    "Parallel snapshot: subtask {}/{}, id range [{}, {}] for table {}.{}",
                     subtaskIndex,
                     numSubtasks,
                     startId,
-                    endId);
+                    endId,
+                    schema,
+                    tbl);
 
             String sql =
                     String.format(
                             "SELECT %s FROM %s.%s WHERE %s >= ? AND %s <= ? ORDER BY %s",
-                            columns, schema, tableName, pkColumn, pkColumn, pkColumn);
+                            columns, schema, tbl, pkColumn, pkColumn, pkColumn);
 
             int count = 0;
             try (PreparedStatement stmt = connection.prepareStatement(sql)) {
@@ -317,7 +352,7 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                 try (ResultSet rs = stmt.executeQuery()) {
                     ResultSetMetaData meta = rs.getMetaData();
                     while (rs.next()) {
-                        RowData row = convertToRowDataDynamic(rs, meta);
+                        RowData row = convertSnapshotRow(rs, meta, tbl);
                         synchronized (ctx.getCheckpointLock()) {
                             ctx.collect(row);
                         }
@@ -330,27 +365,26 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                     subtaskIndex,
                     count,
                     schema,
-                    tableName);
+                    tbl);
         } else {
             // Single subtask: read all data
             String sql =
                     String.format(
-                            "SELECT %s FROM %s.%s ORDER BY %s",
-                            columns, schema, tableName, pkColumn);
+                            "SELECT %s FROM %s.%s ORDER BY %s", columns, schema, tbl, pkColumn);
 
             int count = 0;
             try (PreparedStatement stmt = connection.prepareStatement(sql);
                     ResultSet rs = stmt.executeQuery()) {
                 ResultSetMetaData meta = rs.getMetaData();
                 while (rs.next()) {
-                    RowData row = convertToRowDataDynamic(rs, meta);
+                    RowData row = convertSnapshotRow(rs, meta, tbl);
                     synchronized (ctx.getCheckpointLock()) {
                         ctx.collect(row);
                     }
                     count++;
                 }
             }
-            LOG.info("Snapshot read {} rows from {}.{}", count, schema, tableName);
+            LOG.info("Snapshot read {} rows from {}.{}", count, schema, tbl);
         }
 
         // Capture WAL position AFTER snapshot completes. This ensures the
@@ -363,11 +397,8 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     }
 
     /** Get the min and max id of the table for parallel split calculation. */
-    private long[] getIdRange() throws SQLException {
-        String pkCol = getPrimaryKeyColumn();
-        String sql =
-                String.format(
-                        "SELECT MIN(%s), MAX(%s) FROM %s.%s", pkCol, pkCol, schema, tableName);
+    private long[] getIdRange(String tbl, String pkCol) throws SQLException {
+        String sql = String.format("SELECT MIN(%s), MAX(%s) FROM %s.%s", pkCol, pkCol, schema, tbl);
         try (PreparedStatement stmt = connection.prepareStatement(sql);
                 ResultSet rs = stmt.executeQuery()) {
             if (rs.next()) {
@@ -384,14 +415,34 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     }
 
     /**
-     * Dynamically detect the primary key column name for the table via
+     * Dynamically detect the primary key column name for a table via
      * DatabaseMetaData.getPrimaryKeys(). Falls back to "id" for backward compatibility if no
-     * primary key is found.
+     * primary key is found. Results are cached per-table in {@link #cachedPkByTable}.
+     *
+     * @param tbl the table name to detect PK for
+     * @return the primary key column name
+     */
+    private String getPrimaryKeyColumn(String tbl) throws SQLException {
+        if (cachedPkByTable != null && cachedPkByTable.containsKey(tbl)) {
+            return cachedPkByTable.get(tbl);
+        }
+        String result = detectPrimaryKeyColumn(tbl);
+        if (cachedPkByTable != null) {
+            cachedPkByTable.put(tbl, result);
+        }
+        return result;
+    }
+
+    /**
+     * @deprecated Use {@link #getPrimaryKeyColumn(String)} instead. Kept for backward compatibility
+     *     — delegates to {@code getPrimaryKeyColumn(tableName)}.
      */
     private String getPrimaryKeyColumn() throws SQLException {
-        if (cachedPkColumn != null) {
-            return cachedPkColumn;
-        }
+        return getPrimaryKeyColumn(tableName);
+    }
+
+    /** Actual PK detection logic, parameterized by table name. */
+    private String detectPrimaryKeyColumn(String tbl) throws SQLException {
         // Try DatabaseMetaData.getPrimaryKeys()
         try {
             if (connection == null) {
@@ -399,17 +450,16 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             }
             java.sql.DatabaseMetaData meta = connection.getMetaData();
             if (meta != null) {
-                ResultSet pkRs = meta.getPrimaryKeys(null, schema, tableName);
+                ResultSet pkRs = meta.getPrimaryKeys(null, schema, tbl);
                 if (pkRs != null) {
                     try (ResultSet rs = pkRs) {
                         if (rs.next()) {
                             String pkName = rs.getString("COLUMN_NAME");
                             if (pkName != null && !pkName.isEmpty()) {
-                                cachedPkColumn = pkName;
                                 LOG.info(
                                         "Detected primary key column for {}.{}: {}",
                                         schema,
-                                        tableName,
+                                        tbl,
                                         pkName);
                                 return pkName;
                             }
@@ -418,13 +468,8 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                 }
             }
         } catch (SQLException e) {
-            LOG.warn(
-                    "Failed to detect primary key for {}.{}: {}",
-                    schema,
-                    tableName,
-                    e.getMessage());
+            LOG.warn("Failed to detect primary key for {}.{}: {}", schema, tbl, e.getMessage());
         }
-        // Fallback: try pg_index query
         // Fallback: try pg_index query
         PreparedStatement stmt = null;
         try {
@@ -436,16 +481,15 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             if (stmt == null) {
                 throw new SQLException("prepareStatement returned null");
             }
-            stmt.setString(1, schema + "." + tableName);
+            stmt.setString(1, schema + "." + tbl);
             try (ResultSet rs = stmt.executeQuery()) {
                 if (rs.next()) {
                     String pkName = rs.getString(1);
                     if (pkName != null && !pkName.isEmpty()) {
-                        cachedPkColumn = pkName;
                         LOG.info(
                                 "Detected primary key column (pg_index) for {}.{}: {}",
                                 schema,
-                                tableName,
+                                tbl,
                                 pkName);
                         return pkName;
                     }
@@ -455,7 +499,7 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             LOG.warn(
                     "pg_index primary key detection failed for {}.{}: {}",
                     schema,
-                    tableName,
+                    tbl,
                     e.getMessage());
         } finally {
             if (stmt != null) {
@@ -466,9 +510,8 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             }
         }
         // Final fallback: "id" for backward compatibility
-        LOG.warn("No primary key found for {}.{}; falling back to \"id\"", schema, tableName);
-        cachedPkColumn = "id";
-        return cachedPkColumn;
+        LOG.warn("No primary key found for {}.{}; falling back to \"id\"", schema, tbl);
+        return "id";
     }
 
     /** Phase 2a: WAL streaming using WalReplicationStream. */
@@ -531,13 +574,17 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
 
                     // Filter out changes from non-target tables.
                     // WAL logical decoding captures ALL changes in the database,
-                    // but we only want changes for the configured table.
+                    // but we only want changes for tables matching the configured pattern.
                     String changeSchema = change.getSchema();
                     String changeTable = change.getTable();
-                    if (changeSchema == null
-                            || changeTable == null
-                            || !changeSchema.equalsIgnoreCase(schema)
-                            || !changeTable.equalsIgnoreCase(tableName)) {
+                    if (changeSchema == null || changeTable == null) {
+                        LOG.debug(
+                                "Skipping change with null schema/table: {}.{}",
+                                changeSchema,
+                                changeTable);
+                        continue;
+                    }
+                    if (!isTableMatch(changeSchema, changeTable)) {
                         LOG.debug(
                                 "Skipping change from non-target table: {}.{}",
                                 changeSchema,
@@ -562,19 +609,27 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                     WalChange.ChangeType changeType = change.getType();
                     RowData row = null;
                     try {
-                        if (changeType == WalChange.ChangeType.INSERT) {
-                            row = convertWalColumnsToRowData(change.getAfterColumns());
-                        } else if (changeType == WalChange.ChangeType.UPDATE) {
-                            row = convertWalColumnsToRowData(change.getAfterColumns());
-                        } else if (changeType == WalChange.ChangeType.DELETE) {
-                            row = convertWalColumnsToRowData(change.getBeforeColumns());
-                            if (row != null) {
-                                row.setRowKind(RowKind.DELETE);
+                        if ("json".equalsIgnoreCase(outputFormat)) {
+                            // JSON output mode: single STRING column with all data
+                            row = convertWalChangeToJson(change);
+                        } else {
+                            // Raw output mode: RowData with fixed columns per table
+                            if (changeType == WalChange.ChangeType.INSERT) {
+                                row =
+                                        convertWalColumnsToRowData(
+                                                change.getAfterColumns(), changeTable);
+                            } else if (changeType == WalChange.ChangeType.UPDATE) {
+                                row =
+                                        convertWalColumnsToRowData(
+                                                change.getAfterColumns(), changeTable);
+                            } else if (changeType == WalChange.ChangeType.DELETE) {
+                                row =
+                                        convertWalColumnsToRowData(
+                                                change.getBeforeColumns(), changeTable);
+                                if (row != null) {
+                                    row.setRowKind(RowKind.DELETE);
+                                }
                             }
-                            LOG.debug(
-                                    "Detected DELETE on {}.{}",
-                                    change.getSchema(),
-                                    change.getTable());
                         }
                     } catch (Exception e) {
                         LOG.warn(
@@ -855,38 +910,103 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
 
     // ---- Data conversion helpers ----
 
-    private String getTableColumns() throws SQLException {
+    /**
+     * Discover all tables in the configured schema that match the table-name pattern. Uses regex
+     * matching if table-name contains regex metacharacters, otherwise falls back to exact match.
+     *
+     * @return list of matching table names (never null, may be empty)
+     */
+    private List<String> discoverMatchingTables() throws SQLException {
+        List<String> result = new ArrayList<>();
         DatabaseMetaData meta = connection.getMetaData();
-        List<String> columns = new ArrayList<>();
-        try (ResultSet rs = meta.getColumns(null, schema, tableName, null)) {
+        try (ResultSet rs = meta.getTables(null, schema, "%", new String[] {"TABLE"})) {
             while (rs.next()) {
-                columns.add(rs.getString("COLUMN_NAME"));
+                String tbl = rs.getString("TABLE_NAME");
+                if (tbl != null && isTableMatch(schema, tbl)) {
+                    result.add(tbl);
+                }
             }
         }
-        if (columns.isEmpty()) {
-            throw new SQLException("No columns found for table " + schema + "." + tableName);
-        }
-        return String.join(", ", columns);
+        return result;
     }
 
-    private RowData convertWalColumnsToRowData(List<WalChange.ColumnValue> columns) {
+    /**
+     * Check if a table matches the configured table-name pattern.
+     *
+     * <p>If tablePattern is non-null (regex mode), uses regex matching. Otherwise, does exact
+     * case-insensitive match against tableName.
+     *
+     * @param tableSchema the schema of the change/table (must match configured schema)
+     * @param tbl the table name to check
+     * @return true if the table matches
+     */
+    private boolean isTableMatch(String tableSchema, String tbl) {
+        // Schema must always match
+        if (!tableSchema.equalsIgnoreCase(schema)) {
+            return false;
+        }
+        if (tablePattern != null) {
+            return tablePattern.matcher(tbl).matches();
+        }
+        // Exact match (backward compatible single-table mode)
+        return tbl.equalsIgnoreCase(tableName);
+    }
+
+    /**
+     * Cache column names for a specific table.
+     *
+     * @param tbl the table name
+     */
+    private void cacheTableColumns(String tbl) throws SQLException {
+        if (cachedColumnsByTable.containsKey(tbl)) {
+            return;
+        }
+        DatabaseMetaData meta = connection.getMetaData();
+        List<String> colNames = new ArrayList<>();
+        try (ResultSet rs = meta.getColumns(null, schema, tbl, null)) {
+            while (rs.next()) {
+                colNames.add(rs.getString("COLUMN_NAME"));
+            }
+        }
+        cachedColumnsByTable.put(tbl, colNames);
+        LOG.info("Cached {} columns for table {}.{}: {}", colNames.size(), schema, tbl, colNames);
+    }
+
+    private String getTableColumns(String tbl) throws SQLException {
+        List<String> cols = cachedColumnsByTable.get(tbl);
+        if (cols == null) {
+            cacheTableColumns(tbl);
+            cols = cachedColumnsByTable.get(tbl);
+        }
+        if (cols == null || cols.isEmpty()) {
+            throw new SQLException("No columns found for table " + schema + "." + tbl);
+        }
+        return String.join(", ", cols);
+    }
+
+    /**
+     * Convert WAL column values to RowData using cached column metadata for the specific table.
+     *
+     * @param columns the WAL column values
+     * @param tbl the table name (for looking up cached column metadata)
+     * @return RowData with full row arity
+     */
+    private RowData convertWalColumnsToRowData(List<WalChange.ColumnValue> columns, String tbl) {
         if (columns == null || columns.isEmpty()) {
             return null;
         }
-        // Use cached column count to ensure RowData arity matches the full table schema.
-        // WAL events (especially DELETE) may only contain a subset of columns,
-        // but Flink's serializer expects the full row arity.
-        int colCount = (cachedColumnNames != null) ? cachedColumnNames.size() : columns.size();
+        List<String> cachedCols = cachedColumnsByTable.get(tbl);
+        int colCount = (cachedCols != null) ? cachedCols.size() : columns.size();
         GenericRowData row = new GenericRowData(colCount);
 
-        if (cachedColumnNames != null && !cachedColumnNames.isEmpty()) {
+        if (cachedCols != null && !cachedCols.isEmpty()) {
             // Map WAL columns by name to the correct positions
             java.util.Map<String, WalChange.ColumnValue> colMap = new java.util.HashMap<>();
             for (WalChange.ColumnValue col : columns) {
                 colMap.put(col.getColumnName(), col);
             }
-            for (int i = 0; i < cachedColumnNames.size(); i++) {
-                String colName = cachedColumnNames.get(i);
+            for (int i = 0; i < cachedCols.size(); i++) {
+                String colName = cachedCols.get(i);
                 WalChange.ColumnValue col = colMap.get(colName);
                 if (col == null || col.isNull()) {
                     row.setField(i, null);
@@ -896,7 +1016,17 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                 }
             }
         } else {
-            // Fallback: assume WAL columns are in table order
+            // Fallback: assume WAL columns are in table order.
+            // Try to cache columns for this table on the fly.
+            try {
+                cacheTableColumns(tbl);
+                List<String> freshCols = cachedColumnsByTable.get(tbl);
+                if (freshCols != null && !freshCols.isEmpty()) {
+                    return convertWalColumnsToRowData(columns, tbl);
+                }
+            } catch (SQLException e) {
+                LOG.warn("Failed to cache columns for table {}.{} on the fly", schema, tbl, e);
+            }
             for (int i = 0; i < columns.size(); i++) {
                 WalChange.ColumnValue col = columns.get(i);
                 if (col.isNull()) {
@@ -908,6 +1038,146 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             }
         }
         return row;
+    }
+
+    /**
+     * Convert a WalChange to a single-column RowData containing a JSON string. Used in
+     * output.format=json mode for heterogeneous multi-table capture.
+     *
+     * <p>JSON format:
+     *
+     * <pre>
+     * {"table":"orders","schema":"public","op":"INSERT","lsn":"0/12345678",
+     *  "before":{},"after":{"id":1,"name":"Alice","amount":100.50}}
+     * </pre>
+     *
+     * @param change the WAL change event
+     * @return RowData with a single StringData field containing the JSON string
+     */
+    private RowData convertWalChangeToJson(WalChange change) {
+        StringBuilder sb = new StringBuilder(256);
+        sb.append('{');
+        // table
+        sb.append("\"table\":\"").append(escapeJson(change.getTable())).append('"');
+        // schema
+        sb.append(",\"schema\":\"").append(escapeJson(change.getSchema())).append('"');
+        // op
+        sb.append(",\"op\":\"").append(change.getType().name()).append('"');
+        // lsn
+        if (change.getLsn() != null) {
+            sb.append(",\"lsn\":\"").append(escapeJson(change.getLsn())).append('"');
+        }
+        // before (DELETE/UPDATE)
+        sb.append(",\"before\":");
+        appendColumnsAsJson(sb, change.getBeforeColumns());
+        // after (INSERT/UPDATE)
+        sb.append(",\"after\":");
+        appendColumnsAsJson(sb, change.getAfterColumns());
+        sb.append('}');
+
+        GenericRowData row = new GenericRowData(1);
+        row.setField(0, StringData.fromString(sb.toString()));
+        if (change.getType() == WalChange.ChangeType.DELETE) {
+            row.setRowKind(RowKind.DELETE);
+        }
+        return row;
+    }
+
+    /** Append a list of column values as a JSON object. */
+    private void appendColumnsAsJson(StringBuilder sb, List<WalChange.ColumnValue> columns) {
+        if (columns == null || columns.isEmpty()) {
+            sb.append("{}");
+            return;
+        }
+        sb.append('{');
+        for (int i = 0; i < columns.size(); i++) {
+            if (i > 0) {
+                sb.append(',');
+            }
+            WalChange.ColumnValue col = columns.get(i);
+            sb.append('"').append(escapeJson(col.getColumnName())).append("\":");
+            if (col.isNull()) {
+                sb.append("null");
+            } else {
+                sb.append('"').append(escapeJson(col.getValue())).append('"');
+            }
+        }
+        sb.append('}');
+    }
+
+    /** Escape a string for safe inclusion in a JSON string value. */
+    private String escapeJson(String s) {
+        if (s == null) {
+            return "";
+        }
+        StringBuilder sb = new StringBuilder(s.length() + 16);
+        for (int i = 0; i < s.length(); i++) {
+            char c = s.charAt(i);
+            switch (c) {
+                case '"':
+                    sb.append("\\\"");
+                    break;
+                case '\\':
+                    sb.append("\\\\");
+                    break;
+                case '\n':
+                    sb.append("\\n");
+                    break;
+                case '\r':
+                    sb.append("\\r");
+                    break;
+                case '\t':
+                    sb.append("\\t");
+                    break;
+                default:
+                    if (c < 0x20) {
+                        sb.append(String.format("\\u%04x", (int) c));
+                    } else {
+                        sb.append(c);
+                    }
+            }
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Convert a snapshot ResultSet row to RowData, respecting output.format.
+     *
+     * <p>In raw mode: uses convertToRowDataDynamic (fixed columns). In json mode: wraps the row
+     * data into a JSON string with table name and op=INSERT.
+     */
+    private RowData convertSnapshotRow(ResultSet rs, ResultSetMetaData meta, String tbl)
+            throws SQLException {
+        if ("json".equalsIgnoreCase(outputFormat)) {
+            StringBuilder sb = new StringBuilder(256);
+            sb.append("{\"table\":\"").append(escapeJson(tbl)).append('"');
+            sb.append(",\"schema\":\"").append(escapeJson(schema)).append('"');
+            sb.append(",\"op\":\"INSERT\"");
+            sb.append(",\"before\":{}");
+            sb.append(",\"after\":");
+            // Append all columns as JSON
+            sb.append('{');
+            for (int i = 1; i <= meta.getColumnCount(); i++) {
+                if (i > 1) {
+                    sb.append(',');
+                }
+                String colName = meta.getColumnName(i);
+                sb.append('"').append(escapeJson(colName)).append("\":");
+                String val = rs.getString(i);
+                if (rs.wasNull()) {
+                    sb.append("null");
+                } else {
+                    sb.append('"').append(escapeJson(val)).append('"');
+                }
+            }
+            sb.append('}');
+            sb.append('}');
+            GenericRowData row = new GenericRowData(1);
+            row.setField(0, StringData.fromString(sb.toString()));
+            return row;
+        } else {
+            return convertToRowDataDynamic(rs, meta);
+        }
     }
 
     private Object convertColumnValueByOid(int typeOid, String value) {
@@ -1050,6 +1320,7 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         private boolean sendingBatch = false;
         private String sslMode = GaussDBCDCOptions.SSL_MODE.defaultValue();
         private Integer replicationPort;
+        private String outputFormat = "raw";
 
         public Builder hostname(String hostname) {
             this.hostname = hostname;
@@ -1148,6 +1419,11 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
 
         public Builder replicationPort(Integer replicationPort) {
             this.replicationPort = replicationPort;
+            return this;
+        }
+
+        public Builder outputFormat(String outputFormat) {
+            this.outputFormat = outputFormat;
             return this;
         }
 

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunction.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunction.java
@@ -19,8 +19,10 @@
 package org.apache.flink.connector.gaussdbcdc.source;
 
 import org.apache.flink.annotation.PublicEvolving;
+import org.apache.flink.api.common.state.CheckpointListener;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.api.common.typeinfo.PrimitiveArrayTypeInfo;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.common.typeinfo.Types;
 import org.apache.flink.api.java.typeutils.ResultTypeQueryable;
@@ -31,7 +33,7 @@ import org.apache.flink.connector.gaussdbcdc.source.wal.WalReplicationStream;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
 import org.apache.flink.streaming.api.checkpoint.CheckpointedFunction;
-import org.apache.flink.streaming.api.functions.source.RichSourceFunction;
+import org.apache.flink.streaming.api.functions.source.RichParallelSourceFunction;
 import org.apache.flink.table.data.DecimalData;
 import org.apache.flink.table.data.GenericRowData;
 import org.apache.flink.table.data.RowData;
@@ -49,11 +51,14 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
-import java.sql.Statement;
+import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
+import java.util.TreeMap;
 import java.util.regex.Pattern;
 
 /**
@@ -85,8 +90,8 @@ import java.util.regex.Pattern;
  * </pre>
  */
 @PublicEvolving
-public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
-        implements CheckpointedFunction, ResultTypeQueryable<RowData> {
+public class GaussDBCDCSourceFunction extends RichParallelSourceFunction<RowData>
+        implements CheckpointedFunction, CheckpointListener, ResultTypeQueryable<RowData> {
 
     private static final long serialVersionUID = 1L;
     private static final Logger LOG = LoggerFactory.getLogger(GaussDBCDCSourceFunction.class);
@@ -116,7 +121,6 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     private final String username;
     private final String password;
     private final String slotName;
-    private final String pluginName;
     private final boolean snapshotMode;
     private final int chunkSize;
     private final int connectTimeoutMs;
@@ -134,7 +138,7 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     private final Integer replicationPort;
     /** Output format: "raw" (RowData, default) or "json" (single STRING column with JSON). */
     private final String outputFormat;
-    /** JSON sub-format when output.format=json: "debezium" (default), "canal", or "haier". */
+    /** JSON sub-format when output.format=json: "debezium" (default), "canal", or "he". */
     private final String outputJsonFormat;
 
     /** Compiled regex pattern for table-name matching. Null means exact match on tableName. */
@@ -143,6 +147,7 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     // Runtime state
     private transient volatile boolean running = true;
     private transient Connection connection;
+    private transient String identifierQuoteString;
     private transient WalReplicationStream walReplicationStream;
     private transient ChangeDataPoller changeDataPoller;
     private transient boolean walStreamInitialized = false;
@@ -155,10 +160,39 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     private transient String snapshotStartLsn = null;
     // Last consumed WAL LSN for duplicate filtering in SQL fallback mode
     private transient String lastConsumedLsn = null;
+    // LSN restored from Flink operator state. A restored source must resume from this position
+    // instead of taking a new snapshot and starting from the slot's current position.
+    private transient String restoredLsn = null;
     private transient int walEmitCount = 0;
 
     // Checkpoint state
     private transient ListState<String> offsetState;
+    private transient ListState<byte[]> pollingState;
+    private transient byte[] restoredPollingState;
+    private transient NavigableMap<Long, String> pendingCheckpointLsns;
+    private transient String lastAcknowledgedLsn;
+
+    // Database-backed snapshot coordination. Each source subtask owns a distinct advisory lock;
+    // subtask 0 uses an additional gate lock to form start/end barriers without external storage.
+    private transient int snapshotCoordinationKey;
+    private transient boolean snapshotCoordinationActive;
+    private transient boolean snapshotTransactionActive;
+    private transient long snapshotCsn = -1L;
+    private transient Map<Long, PendingWalTransaction> pendingWalTransactions;
+    private transient Deque<PendingWalTransaction> pendingWalTransactionOrder;
+    private transient String lastCommittedWalLsn;
+
+    private static final class PendingWalTransaction {
+        private final long xid;
+        private final List<WalChange> changes = new ArrayList<>();
+        private boolean committed;
+        private String commitLsn;
+        private long commitCsn;
+
+        private PendingWalTransaction(long xid) {
+            this.xid = xid;
+        }
+    }
 
     public GaussDBCDCSourceFunction(Builder builder) {
         this.hostname = builder.hostname;
@@ -169,7 +203,6 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         this.username = builder.username;
         this.password = builder.password;
         this.slotName = builder.slotName;
-        this.pluginName = builder.pluginName;
         this.snapshotMode = builder.snapshotMode;
         this.chunkSize = builder.chunkSize;
         this.connectTimeoutMs = builder.connectTimeoutMs;
@@ -183,6 +216,49 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         this.replicationPort = builder.replicationPort;
         this.outputFormat = builder.outputFormat;
         this.outputJsonFormat = builder.outputJsonFormat;
+        validateConfiguration();
+    }
+
+    private void validateConfiguration() {
+        if (!"raw".equalsIgnoreCase(outputFormat) && !"json".equalsIgnoreCase(outputFormat)) {
+            throw new IllegalArgumentException(
+                    "Unsupported output.format: "
+                            + outputFormat
+                            + ". Supported values are raw and json.");
+        }
+        if ("json".equalsIgnoreCase(outputFormat)
+                && !"debezium".equalsIgnoreCase(outputJsonFormat)
+                && !"canal".equalsIgnoreCase(outputJsonFormat)
+                && !"he".equalsIgnoreCase(outputJsonFormat)) {
+            throw new IllegalArgumentException(
+                    "Unsupported output.json.format: "
+                            + outputJsonFormat
+                            + ". Supported values are debezium, canal, and he.");
+        }
+        if (chunkSize <= 0) {
+            throw new IllegalArgumentException("chunk.size must be greater than zero");
+        }
+        if (connectTimeoutMs <= 0) {
+            throw new IllegalArgumentException("connect.timeout.ms must be greater than zero");
+        }
+        if (pollIntervalMs <= 0) {
+            throw new IllegalArgumentException("poll.interval.ms must be greater than zero");
+        }
+        if (parallelDecodeNum < 1 || parallelDecodeNum > 20) {
+            throw new IllegalArgumentException("parallel-decode-num must be between 1 and 20");
+        }
+        if (!"b".equalsIgnoreCase(decodeStyle)
+                && !"j".equalsIgnoreCase(decodeStyle)
+                && !"t".equalsIgnoreCase(decodeStyle)) {
+            throw new IllegalArgumentException("decode-style must be one of b, j, or t");
+        }
+    }
+
+    private String buildJdbcUrl() {
+        long timeoutSeconds = Math.max(1L, (connectTimeoutMs + 999L) / 1000L);
+        return String.format(
+                "jdbc:gaussdb://%s:%d/%s?sslmode=%s&connectTimeout=%d",
+                hostname, port, database, sslMode, timeoutSeconds);
     }
 
     @Override
@@ -191,10 +267,18 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         this.running = true; // transient field reset on deserialization, must re-initialize
         Class.forName("com.huawei.gaussdb.jdbc.Driver");
 
-        String url =
-                String.format(
-                        "jdbc:gaussdb://%s:%d/%s?sslmode=%s", hostname, port, database, sslMode);
+        String url = buildJdbcUrl();
         this.connection = DriverManager.getConnection(url, username, password);
+        this.identifierQuoteString = SqlIdentifierUtils.resolveQuoteString(connection);
+        this.pendingCheckpointLsns = new TreeMap<>();
+        this.lastAcknowledgedLsn = null;
+        this.snapshotCoordinationKey =
+                java.util.Objects.hash(database, schema, slotName, tableName);
+        this.snapshotCoordinationActive = false;
+        this.snapshotTransactionActive = false;
+        this.pendingWalTransactions = new HashMap<>();
+        this.pendingWalTransactionOrder = new ArrayDeque<>();
+        this.lastCommittedWalLsn = null;
 
         // Initialize multi-table structures
         this.cachedColumnsByTable = new HashMap<>();
@@ -219,7 +303,7 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                             parallelDecodeNum,
                             decodeStyle,
                             sendingBatch,
-                            1000,
+                            chunkSize,
                             replicationPort);
             if (replicationPort != null) {
                 LOG.info(
@@ -242,7 +326,18 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             }
             LOG.info("Discovered {} matching table(s): {}", matchedTables.size(), matchedTables);
             this.changeDataPoller =
-                    new ChangeDataPoller(connection, schema, matchedTables, outputFormat);
+                    new ChangeDataPoller(
+                            connection,
+                            database,
+                            schema,
+                            matchedTables,
+                            outputFormat,
+                            outputJsonFormat,
+                            chunkSize);
+            if (restoredPollingState != null) {
+                changeDataPoller.restoreState(restoredPollingState);
+                LOG.info("Restored polling CDC state from the latest completed checkpoint");
+            }
             LOG.info("Using polling-based CDC mode for {} table(s)", matchedTables.size());
         }
 
@@ -275,19 +370,58 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
 
     @Override
     public void run(SourceContext<RowData> ctx) throws Exception {
-        // Phase 1: Snapshot - read initial table data
-        if (snapshotMode) {
-            List<String> tables = discoverMatchingTables();
+        if (!running) {
+            return;
+        }
+        int subtaskIndex = getRuntimeContext().getIndexOfThisSubtask();
+        int sourceParallelism = getRuntimeContext().getNumberOfParallelSubtasks();
+
+        // Polling mode has one in-memory state store and cannot safely run one poller per subtask.
+        // Keep it single-active even when the surrounding job has a higher parallelism.
+        if (!walMode && subtaskIndex != 0) {
             LOG.info(
-                    "Starting snapshot phase for {} table(s) matching '{}': {}",
-                    tables.size(),
-                    tableName,
-                    tables);
-            for (String tbl : tables) {
-                readSnapshot(ctx, tbl);
-                LOG.info("Snapshot completed for table {}.{}", schema, tbl);
+                    "Polling source subtask {}/{} is idle; polling is handled by subtask 0",
+                    subtaskIndex,
+                    sourceParallelism);
+            return;
+        }
+
+        // Phase 1: Snapshot - read initial table data
+        boolean restoredSourceState = walMode ? restoredLsn != null : restoredPollingState != null;
+        if (snapshotMode && !restoredSourceState) {
+            List<String> tables = discoverMatchingTables();
+            boolean coordinatedSnapshot = walMode;
+            try {
+                if (coordinatedSnapshot) {
+                    beginCoordinatedSnapshot(tables);
+                }
+                LOG.info(
+                        "Starting snapshot phase for {} table(s) matching '{}': {}",
+                        tables.size(),
+                        tableName,
+                        tables);
+                for (String tbl : tables) {
+                    readSnapshot(ctx, tbl);
+                    LOG.info("Snapshot completed for table {}.{}", schema, tbl);
+                }
+                if (coordinatedSnapshot) {
+                    completeCoordinatedSnapshot();
+                }
+                LOG.info("Snapshot phase completed for all {} table(s)", tables.size());
+            } catch (Exception e) {
+                if (coordinatedSnapshot) {
+                    abortCoordinatedSnapshot();
+                }
+                throw e;
             }
-            LOG.info("Snapshot phase completed for all {} table(s)", tables.size());
+        } else if (snapshotMode) {
+            if (walMode) {
+                LOG.info(
+                        "Skipping snapshot after checkpoint restore; WAL will resume from LSN {}",
+                        restoredLsn);
+            } else {
+                LOG.info("Skipping snapshot after restoring polling CDC state");
+            }
         }
 
         // Phase 2: Streaming - continuously capture changes
@@ -297,8 +431,19 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                 runWalStreaming(ctx);
             } else {
                 LOG.info(
-                        "Subtask {} finished snapshot, WAL streaming handled by subtask 0",
+                        "Subtask {} finished snapshot; remaining active for checkpoints while WAL streaming is handled by subtask 0",
                         getRuntimeContext().getIndexOfThisSubtask());
+                // A bounded/finished source subtask makes subsequent streaming checkpoints fail
+                // with "task is closing". Keep snapshot-only subtasks alive so every parallel
+                // operator instance continues to acknowledge checkpoint barriers.
+                while (running) {
+                    try {
+                        Thread.sleep(Math.max(100L, pollIntervalMs));
+                    } catch (InterruptedException e) {
+                        Thread.currentThread().interrupt();
+                        break;
+                    }
+                }
             }
         } else {
             runPollingStreaming(ctx);
@@ -307,31 +452,39 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
 
     /** Phase 1: Read initial snapshot via JDBC SELECT with parallel split support. */
     private void readSnapshot(SourceContext<RowData> ctx, String tbl) throws SQLException {
-        // Record WAL position BEFORE snapshot for diagnostics.
-        if (walMode) {
-            String preSnapshotLsn = getSlotConfirmedFlush();
-            LOG.info("Pre-snapshot WAL LSN: {}", preSnapshotLsn);
-        }
-
-        int subtaskIndex = getRuntimeContext().getIndexOfThisSubtask();
-        int numSubtasks = getRuntimeContext().getNumberOfParallelSubtasks();
+        boolean activePollingSource = !walMode && changeDataPoller != null;
+        int subtaskIndex = activePollingSource ? 0 : getRuntimeContext().getIndexOfThisSubtask();
+        int numSubtasks =
+                activePollingSource ? 1 : getRuntimeContext().getNumberOfParallelSubtasks();
         String columns = getTableColumns(tbl);
         String pkColumn = getPrimaryKeyColumn(tbl);
+        String quotedTable = qualifiedTable(tbl);
+        String quotedPkColumn = quoteIdentifier(pkColumn);
 
-        if (numSubtasks > 1) {
+        boolean rangeSplittable = numSubtasks > 1 && isNumericPrimaryKey(tbl, pkColumn);
+        if (numSubtasks > 1 && !rangeSplittable && subtaskIndex != 0) {
+            LOG.info(
+                    "Snapshot for {}.{} has a non-numeric primary key; subtask {} is idle while subtask 0 reads the table",
+                    schema,
+                    tbl,
+                    subtaskIndex);
+            return;
+        }
+
+        if (rangeSplittable) {
             // Parallel snapshot: each subtask reads a different id range
             long[] range = getIdRange(tbl, pkColumn);
             long minId = range[0];
             long maxId = range[1];
             long totalRange = maxId - minId + 1;
-            long chunkSize = totalRange / numSubtasks;
+            long rangeSize = totalRange / numSubtasks;
 
-            long startId = minId + (long) subtaskIndex * chunkSize;
+            long startId = minId + (long) subtaskIndex * rangeSize;
             long endId;
             if (subtaskIndex == numSubtasks - 1) {
                 endId = maxId;
             } else {
-                endId = minId + (long) (subtaskIndex + 1) * chunkSize - 1;
+                endId = minId + (long) (subtaskIndex + 1) * rangeSize - 1;
             }
 
             LOG.info(
@@ -345,11 +498,12 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
 
             String sql =
                     String.format(
-                            "SELECT %s FROM %s.%s WHERE %s >= ? AND %s <= ? ORDER BY %s",
-                            columns, schema, tbl, pkColumn, pkColumn, pkColumn);
+                            "SELECT %s FROM %s WHERE %s >= ? AND %s <= ? ORDER BY %s",
+                            columns, quotedTable, quotedPkColumn, quotedPkColumn, quotedPkColumn);
 
             int count = 0;
             try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+                stmt.setFetchSize(chunkSize);
                 stmt.setLong(1, startId);
                 stmt.setLong(2, endId);
                 try (ResultSet rs = stmt.executeQuery()) {
@@ -373,35 +527,419 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             // Single subtask: read all data
             String sql =
                     String.format(
-                            "SELECT %s FROM %s.%s ORDER BY %s", columns, schema, tbl, pkColumn);
+                            "SELECT %s FROM %s ORDER BY %s", columns, quotedTable, quotedPkColumn);
 
             int count = 0;
-            try (PreparedStatement stmt = connection.prepareStatement(sql);
-                    ResultSet rs = stmt.executeQuery()) {
-                ResultSetMetaData meta = rs.getMetaData();
-                while (rs.next()) {
-                    RowData row = convertSnapshotRow(rs, meta, tbl);
-                    synchronized (ctx.getCheckpointLock()) {
-                        ctx.collect(row);
+            try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+                stmt.setFetchSize(chunkSize);
+                try (ResultSet rs = stmt.executeQuery()) {
+                    ResultSetMetaData meta = rs.getMetaData();
+                    while (rs.next()) {
+                        RowData row = convertSnapshotRow(rs, meta, tbl);
+                        synchronized (ctx.getCheckpointLock()) {
+                            ctx.collect(row);
+                        }
+                        count++;
                     }
-                    count++;
                 }
             }
             LOG.info("Snapshot read {} rows from {}.{}", count, schema, tbl);
         }
+    }
 
-        // Capture WAL position AFTER snapshot completes. This ensures the
-        // WAL stream starts from a position that is strictly after all
-        // data already captured by the snapshot, preventing duplicates.
-        if (walMode && getRuntimeContext().getIndexOfThisSubtask() == 0) {
-            snapshotStartLsn = getSlotConfirmedFlush();
-            LOG.info("Recorded post-snapshot WAL start LSN: {}", snapshotStartLsn);
+    private boolean isNumericPrimaryKey(String tbl, String pkColumn) throws SQLException {
+        DatabaseMetaData meta = connection.getMetaData();
+        try (ResultSet rs = meta.getColumns(null, schema, tbl, null)) {
+            while (rs.next()) {
+                if (!pkColumn.equalsIgnoreCase(rs.getString("COLUMN_NAME"))) {
+                    continue;
+                }
+                int type = rs.getInt("DATA_TYPE");
+                switch (type) {
+                    case java.sql.Types.TINYINT:
+                    case java.sql.Types.SMALLINT:
+                    case java.sql.Types.INTEGER:
+                    case java.sql.Types.BIGINT:
+                        return true;
+                    default:
+                        return false;
+                }
+            }
+        }
+        return false;
+    }
+
+    /** Coordinate a non-blocking parallel snapshot using one exported GaussDB MVCC snapshot. */
+    private void beginCoordinatedSnapshot(List<String> tables) throws Exception {
+        int subtask = getRuntimeContext().getIndexOfThisSubtask();
+        int parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
+        final int gateLock = -1;
+
+        if (subtask == 0) {
+            waitAndAcquireAdvisoryLock(gateLock);
+            snapshotStartLsn = walReplicationStream.prepareSlotForSnapshot();
+            SnapshotBoundary boundary = exportSnapshotBoundary();
+            snapshotCsn = boundary.csn;
+            publishSnapshotBoundary(boundary);
+            waitAndAcquireAdvisoryLock(subtask);
+            snapshotCoordinationActive = true;
+            waitForAllSnapshotSubtasks(parallelism);
+            LOG.info(
+                    "Parallel snapshot barrier ready: parallelism={}, tables={}, startLsn={}, snapshotCsn={}",
+                    parallelism,
+                    tables.size(),
+                    snapshotStartLsn,
+                    snapshotCsn);
+            releaseAdvisoryLock(gateLock);
+        } else {
+            waitForAdvisoryLockHeld(0);
+            SnapshotBoundary boundary = waitForPublishedSnapshotBoundary();
+            importSnapshotBoundary(boundary.snapshotId);
+            waitAndAcquireAdvisoryLock(subtask);
+            snapshotCoordinationActive = true;
+            waitForAdvisoryLockReleased(gateLock);
+        }
+    }
+
+    private void completeCoordinatedSnapshot() throws Exception {
+        int subtask = getRuntimeContext().getIndexOfThisSubtask();
+        int parallelism = getRuntimeContext().getNumberOfParallelSubtasks();
+
+        if (subtask == 0) {
+            // Keep the exporting transaction open until every reader has finished its imported
+            // snapshot. Business DML is never locked and continues using newer MVCC versions.
+            for (int i = 1; i < parallelism; i++) {
+                waitForAdvisoryLockReleased(i);
+            }
+            commitSnapshotTransaction();
+            releaseAdvisoryLock(0);
+        } else {
+            commitSnapshotTransaction();
+            releaseAdvisoryLock(subtask);
+        }
+        snapshotCoordinationActive = false;
+    }
+
+    private void abortCoordinatedSnapshot() {
+        try {
+            if (snapshotTransactionActive) {
+                connection.rollback();
+                snapshotTransactionActive = false;
+            }
+            if (connection != null && !connection.getAutoCommit()) {
+                connection.setAutoCommit(true);
+            }
+            clearPublishedSnapshotBoundary();
+        } catch (Exception e) {
+            LOG.warn("Failed to roll back coordinated snapshot transaction: {}", e.getMessage());
+        }
+        if (snapshotCoordinationActive) {
+            try {
+                releaseAdvisoryLock(getRuntimeContext().getIndexOfThisSubtask());
+                if (getRuntimeContext().getIndexOfThisSubtask() == 0) {
+                    releaseAdvisoryLock(-1);
+                }
+            } catch (Exception e) {
+                LOG.warn("Failed to release snapshot advisory locks: {}", e.getMessage());
+            }
+        }
+        snapshotCoordinationActive = false;
+    }
+
+    private SnapshotBoundary exportSnapshotBoundary() throws SQLException {
+        boolean combinedExportAvailable = isSnapshotFunctionAvailable("pg_export_snapshot_and_csn");
+        if (combinedExportAvailable) {
+            try {
+                return exportSnapshotAndCsnTogether();
+            } catch (SQLException combinedFailure) {
+                rollbackSnapshotExportAttempt(combinedFailure);
+                LOG.warn(
+                        "pg_export_snapshot_and_csn() failed; falling back to standard snapshot export: {}",
+                        combinedFailure.getMessage());
+            }
+        }
+
+        boolean currentCsnAvailable = isSnapshotFunctionAvailable("pg_current_csn");
+        beginSnapshotExportTransaction();
+        long csn = -1L;
+        if (currentCsnAvailable) {
+            try {
+                // Pin the REPEATABLE READ transaction snapshot before exporting it. Reading a
+                // moving current CSN after pg_export_snapshot() could include transactions that
+                // are not visible in the exported snapshot and cause data loss during filtering.
+                csn = queryCurrentCsn();
+            } catch (SQLException csnFailure) {
+                rollbackSnapshotExportAttempt(csnFailure);
+                LOG.warn(
+                        "pg_current_csn() failed; exporting a snapshot without CSN overlap filtering: {}",
+                        csnFailure.getMessage());
+                beginSnapshotExportTransaction();
+            }
+        }
+
+        String snapshotId = querySingleText("SELECT pg_catalog.pg_export_snapshot()");
+        if (csn < 0) {
+            LOG.warn(
+                    "GaussDB does not expose an atomic snapshot CSN; snapshot/WAL overlap filtering is disabled. "
+                            + "Recovery remains lossless but duplicate events may occur at the initial snapshot boundary.");
+        }
+        return new SnapshotBoundary(snapshotId, csn);
+    }
+
+    private SnapshotBoundary exportSnapshotAndCsnTogether() throws SQLException {
+        beginSnapshotExportTransaction();
+        try (PreparedStatement export =
+                        connection.prepareStatement(
+                                "SELECT * FROM pg_catalog.pg_export_snapshot_and_csn()");
+                ResultSet rs = export.executeQuery()) {
+            if (!rs.next()) {
+                throw new SQLException("pg_export_snapshot_and_csn() returned no row");
+            }
+            String snapshotId = rs.getString(1);
+            String csnText = rs.getString(2);
+            try {
+                return new SnapshotBoundary(snapshotId, Long.parseUnsignedLong(csnText, 16));
+            } catch (NumberFormatException e) {
+                throw new SQLException("Invalid hexadecimal snapshot CSN: " + csnText, e);
+            }
+        }
+    }
+
+    private void beginSnapshotExportTransaction() throws SQLException {
+        connection.setAutoCommit(false);
+        snapshotTransactionActive = true;
+        try (PreparedStatement isolation =
+                connection.prepareStatement("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ")) {
+            isolation.execute();
+        }
+    }
+
+    private boolean isSnapshotFunctionAvailable(String functionName) {
+        String sql =
+                "SELECT EXISTS (SELECT 1 FROM pg_catalog.pg_proc p "
+                        + "JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace "
+                        + "WHERE n.nspname = 'pg_catalog' AND p.proname = ? AND p.pronargs = 0)";
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setString(1, functionName);
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next() && rs.getBoolean(1);
+            }
+        } catch (SQLException e) {
+            LOG.warn(
+                    "Could not probe GaussDB function {}(); treating it as unavailable: {}",
+                    functionName,
+                    e.getMessage());
+            return false;
+        }
+    }
+
+    private long queryCurrentCsn() throws SQLException {
+        try (PreparedStatement stmt =
+                        connection.prepareStatement("SELECT pg_catalog.pg_current_csn()");
+                ResultSet rs = stmt.executeQuery()) {
+            if (!rs.next()) {
+                throw new SQLException("pg_current_csn() returned no row");
+            }
+            Object value = rs.getObject(1);
+            if (value instanceof Number) {
+                return ((Number) value).longValue();
+            }
+            if (value == null) {
+                throw new SQLException("pg_current_csn() returned null");
+            }
+            String text = value.toString().trim();
+            try {
+                if (text.startsWith("0x") || text.startsWith("0X")) {
+                    return Long.parseUnsignedLong(text.substring(2), 16);
+                }
+                if (text.matches(".*[A-Fa-f].*")) {
+                    return Long.parseUnsignedLong(text, 16);
+                }
+                return Long.parseUnsignedLong(text, 10);
+            } catch (NumberFormatException e) {
+                throw new SQLException("Invalid current CSN: " + text, e);
+            }
+        }
+    }
+
+    private String querySingleText(String sql) throws SQLException {
+        try (PreparedStatement stmt = connection.prepareStatement(sql);
+                ResultSet rs = stmt.executeQuery()) {
+            if (!rs.next()) {
+                throw new SQLException(sql + " returned no row");
+            }
+            String value = rs.getString(1);
+            if (value == null || value.isEmpty()) {
+                throw new SQLException(sql + " returned an empty value");
+            }
+            return value;
+        }
+    }
+
+    private void rollbackSnapshotExportAttempt(SQLException originalFailure) throws SQLException {
+        try {
+            connection.rollback();
+            snapshotTransactionActive = false;
+            connection.setAutoCommit(true);
+        } catch (SQLException rollbackFailure) {
+            originalFailure.addSuppressed(rollbackFailure);
+            throw originalFailure;
+        }
+    }
+
+    private void importSnapshotBoundary(String snapshotId) throws SQLException {
+        if (snapshotId == null || !snapshotId.matches("[0-9A-Fa-f-]+")) {
+            throw new SQLException("Invalid exported snapshot identifier: " + snapshotId);
+        }
+        connection.setAutoCommit(false);
+        snapshotTransactionActive = true;
+        try (PreparedStatement isolation =
+                        connection.prepareStatement(
+                                "SET TRANSACTION ISOLATION LEVEL REPEATABLE READ");
+                PreparedStatement importSnapshot =
+                        connection.prepareStatement(
+                                "SET TRANSACTION SNAPSHOT '" + snapshotId + "'")) {
+            isolation.execute();
+            importSnapshot.execute();
+        }
+    }
+
+    private void publishSnapshotBoundary(SnapshotBoundary boundary) throws SQLException {
+        String applicationName =
+                snapshotBoundaryPrefix()
+                        + boundary.snapshotId
+                        + ":"
+                        + Long.toHexString(boundary.csn).toUpperCase(java.util.Locale.ROOT);
+        try (PreparedStatement stmt =
+                connection.prepareStatement("SELECT set_config('application_name', ?, false)")) {
+            stmt.setString(1, applicationName);
+            stmt.execute();
+        }
+    }
+
+    private SnapshotBoundary waitForPublishedSnapshotBoundary() throws Exception {
+        String sql =
+                "SELECT application_name FROM pg_stat_activity "
+                        + "WHERE datname = current_database() AND usename = current_user "
+                        + "AND application_name LIKE ? ORDER BY backend_start DESC LIMIT 1";
+        while (running) {
+            try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+                stmt.setString(1, snapshotBoundaryPrefix() + "%");
+                try (ResultSet rs = stmt.executeQuery()) {
+                    if (rs.next()) {
+                        String value = rs.getString(1).substring(snapshotBoundaryPrefix().length());
+                        int separator = value.lastIndexOf(':');
+                        if (separator > 0) {
+                            return new SnapshotBoundary(
+                                    value.substring(0, separator),
+                                    Long.parseUnsignedLong(value.substring(separator + 1), 16));
+                        }
+                    }
+                }
+            }
+            Thread.sleep(50L);
+        }
+        throw new InterruptedException("Source cancelled while waiting for exported snapshot");
+    }
+
+    private void clearPublishedSnapshotBoundary() throws SQLException {
+        if (connection == null || connection.isClosed()) {
+            return;
+        }
+        try (PreparedStatement stmt =
+                connection.prepareStatement("SELECT set_config('application_name', '', false)")) {
+            stmt.execute();
+        }
+    }
+
+    private String snapshotBoundaryPrefix() {
+        return "flink_gdbc_" + Integer.toUnsignedString(snapshotCoordinationKey) + ":";
+    }
+
+    private void commitSnapshotTransaction() throws SQLException {
+        if (snapshotTransactionActive) {
+            connection.commit();
+            snapshotTransactionActive = false;
+        }
+        connection.setAutoCommit(true);
+    }
+
+    private void waitForAllSnapshotSubtasks(int parallelism) throws Exception {
+        for (int i = 1; i < parallelism; i++) {
+            waitForAdvisoryLockHeld(i);
+        }
+    }
+
+    private void waitForAdvisoryLockHeld(int lockId) throws Exception {
+        while (running) {
+            if (!tryAcquireAdvisoryLock(lockId)) {
+                return;
+            }
+            releaseAdvisoryLock(lockId);
+            Thread.sleep(50L);
+        }
+        throw new InterruptedException("Source cancelled while waiting for snapshot start barrier");
+    }
+
+    private void waitForAdvisoryLockReleased(int lockId) throws Exception {
+        while (running) {
+            if (tryAcquireAdvisoryLock(lockId)) {
+                releaseAdvisoryLock(lockId);
+                return;
+            }
+            Thread.sleep(50L);
+        }
+        throw new InterruptedException(
+                "Source cancelled while waiting for snapshot completion barrier");
+    }
+
+    private void waitAndAcquireAdvisoryLock(int lockId) throws Exception {
+        while (running) {
+            if (tryAcquireAdvisoryLock(lockId)) {
+                return;
+            }
+            Thread.sleep(50L);
+        }
+        throw new InterruptedException(
+                "Source cancelled while acquiring snapshot coordinator lock");
+    }
+
+    private boolean tryAcquireAdvisoryLock(int lockId) throws SQLException {
+        String sql = "SELECT pg_try_advisory_lock(?, ?)";
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setInt(1, snapshotCoordinationKey);
+            stmt.setInt(2, lockId);
+            try (ResultSet rs = stmt.executeQuery()) {
+                return rs.next() && rs.getBoolean(1);
+            }
+        }
+    }
+
+    private void releaseAdvisoryLock(int lockId) throws SQLException {
+        String sql = "SELECT pg_advisory_unlock(?, ?)";
+        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setInt(1, snapshotCoordinationKey);
+            stmt.setInt(2, lockId);
+            stmt.execute();
+        }
+    }
+
+    private static final class SnapshotBoundary {
+        private final String snapshotId;
+        private final long csn;
+
+        private SnapshotBoundary(String snapshotId, long csn) {
+            this.snapshotId = snapshotId;
+            this.csn = csn;
         }
     }
 
     /** Get the min and max id of the table for parallel split calculation. */
     private long[] getIdRange(String tbl, String pkCol) throws SQLException {
-        String sql = String.format("SELECT MIN(%s), MAX(%s) FROM %s.%s", pkCol, pkCol, schema, tbl);
+        String quotedPk = quoteIdentifier(pkCol);
+        String sql =
+                String.format(
+                        "SELECT MIN(%s), MAX(%s) FROM %s", quotedPk, quotedPk, qualifiedTable(tbl));
         try (PreparedStatement stmt = connection.prepareStatement(sql);
                 ResultSet rs = stmt.executeQuery()) {
             if (rs.next()) {
@@ -456,21 +994,31 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                 ResultSet pkRs = meta.getPrimaryKeys(null, schema, tbl);
                 if (pkRs != null) {
                     try (ResultSet rs = pkRs) {
-                        if (rs.next()) {
+                        List<String> pkColumns = new ArrayList<>();
+                        while (rs.next()) {
                             String pkName = rs.getString("COLUMN_NAME");
                             if (pkName != null && !pkName.isEmpty()) {
-                                LOG.info(
-                                        "Detected primary key column for {}.{}: {}",
-                                        schema,
-                                        tbl,
-                                        pkName);
-                                return pkName;
+                                pkColumns.add(pkName);
                             }
+                        }
+                        if (pkColumns.size() == 1) {
+                            LOG.info(
+                                    "Detected primary key column for {}.{}: {}",
+                                    schema,
+                                    tbl,
+                                    pkColumns.get(0));
+                            return pkColumns.get(0);
+                        }
+                        if (pkColumns.size() > 1) {
+                            throw unsupportedPrimaryKey(tbl, pkColumns);
                         }
                     }
                 }
             }
         } catch (SQLException e) {
+            if (isUnsupportedPrimaryKey(e)) {
+                throw e;
+            }
             LOG.warn("Failed to detect primary key for {}.{}: {}", schema, tbl, e.getMessage());
         }
         // Fallback: try pg_index query
@@ -480,25 +1028,39 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                     connection.prepareStatement(
                             "SELECT a.attname FROM pg_index i "
                                     + "JOIN pg_attribute a ON a.attrelid = i.indrelid AND a.attnum = ANY(i.indkey) "
-                                    + "WHERE i.indrelid = ?::regclass AND i.indisprimary LIMIT 1");
+                                    + "JOIN pg_class c ON c.oid = i.indrelid "
+                                    + "JOIN pg_namespace n ON n.oid = c.relnamespace "
+                                    + "WHERE n.nspname = ? AND c.relname = ? AND i.indisprimary "
+                                    + "ORDER BY a.attnum");
             if (stmt == null) {
                 throw new SQLException("prepareStatement returned null");
             }
-            stmt.setString(1, schema + "." + tbl);
+            stmt.setString(1, schema);
+            stmt.setString(2, tbl);
             try (ResultSet rs = stmt.executeQuery()) {
-                if (rs.next()) {
+                List<String> pkColumns = new ArrayList<>();
+                while (rs.next()) {
                     String pkName = rs.getString(1);
                     if (pkName != null && !pkName.isEmpty()) {
-                        LOG.info(
-                                "Detected primary key column (pg_index) for {}.{}: {}",
-                                schema,
-                                tbl,
-                                pkName);
-                        return pkName;
+                        pkColumns.add(pkName);
                     }
+                }
+                if (pkColumns.size() == 1) {
+                    LOG.info(
+                            "Detected primary key column (pg_index) for {}.{}: {}",
+                            schema,
+                            tbl,
+                            pkColumns.get(0));
+                    return pkColumns.get(0);
+                }
+                if (pkColumns.size() > 1) {
+                    throw unsupportedPrimaryKey(tbl, pkColumns);
                 }
             }
         } catch (SQLException e) {
+            if (isUnsupportedPrimaryKey(e)) {
+                throw e;
+            }
             LOG.warn(
                     "pg_index primary key detection failed for {}.{}: {}",
                     schema,
@@ -512,9 +1074,23 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                 }
             }
         }
-        // Final fallback: "id" for backward compatibility
-        LOG.warn("No primary key found for {}.{}; falling back to \"id\"", schema, tbl);
-        return "id";
+        throw new SQLException(
+                "GaussDB CDC requires a primary key, but none was found for " + schema + "." + tbl);
+    }
+
+    private SQLException unsupportedPrimaryKey(String tbl, List<String> columns) {
+        return new SQLException(
+                "GaussDB CDC currently requires a single-column primary key for "
+                        + schema
+                        + "."
+                        + tbl
+                        + "; found composite key "
+                        + columns);
+    }
+
+    private boolean isUnsupportedPrimaryKey(SQLException e) {
+        return e.getMessage() != null
+                && e.getMessage().startsWith("GaussDB CDC currently requires a single-column");
     }
 
     /** Phase 2a: WAL streaming using WalReplicationStream. */
@@ -523,11 +1099,14 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             LOG.info("Initializing WAL replication stream for incremental phase");
             // Start WAL streaming from the snapshot start LSN to avoid
             // replaying data already emitted during the initial snapshot
-            if (snapshotStartLsn != null) {
+            String startLsn = restoredLsn != null ? restoredLsn : snapshotStartLsn;
+            if (startLsn != null) {
                 LOG.info(
-                        "Starting WAL stream from snapshot start LSN: {}, skipping already-snapshot data",
-                        snapshotStartLsn);
-                walReplicationStream.initialize(snapshotStartLsn);
+                        "Starting WAL stream from LSN: {} (source={})",
+                        startLsn,
+                        restoredLsn != null ? "checkpoint" : "snapshot");
+                walReplicationStream.initialize(startLsn);
+                lastConsumedLsn = startLsn;
             } else {
                 walReplicationStream.initialize();
             }
@@ -536,31 +1115,15 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                     "WAL stream initialized, starting from LSN: {}",
                     walReplicationStream.getLastLsn());
 
-            // The JDBC replication API may replay WAL data from the slot's
-            // existing position, which can be earlier than the snapshot LSN.
-            // Read and discard initial data to establish a consumed LSN watermark.
-            // This handles both JDBC Replication API and SQL function fallback.
-            try {
-                List<WalChange> discard = walReplicationStream.readChanges(10000);
-                if (!discard.isEmpty()) {
-                    LOG.info("Discarded {} stale WAL changes after snapshot", discard.size());
-                    WalChange first = discard.get(0);
-                    WalChange last = discard.get(discard.size() - 1);
-                    LOG.info("[DIAG] Discarded range: {} → {}", first.getLsn(), last.getLsn());
-                } else {
-                    LOG.info("[DIAG] No stale data to discard");
-                }
-                lastConsumedLsn = walReplicationStream.getLastLsn();
-                LOG.info("[DIAG] lastConsumedLsn = {}", lastConsumedLsn);
-            } catch (Exception e) {
-                LOG.warn("Failed to discard stale WAL data: {}", e.getMessage());
-            }
+            // Do not discard the first returned batch here. The slot was established before the
+            // snapshot and per-change LSN filtering removes records at or before that boundary. A
+            // blind first-batch discard drops legitimate changes committed during the snapshot.
         }
 
         LOG.info("Entering WAL streaming loop, running={}", running);
         while (running) {
             try {
-                List<WalChange> changes = walReplicationStream.readChanges(1000);
+                List<WalChange> changes = walReplicationStream.readChanges(chunkSize);
                 String streamLsn = walReplicationStream.getLastLsn();
                 if (!changes.isEmpty()) {
                     LOG.info(
@@ -570,93 +1133,109 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                             streamLsn);
                 }
 
-                for (WalChange change : changes) {
-                    if (!change.isDataChange()) {
-                        continue;
-                    }
+                List<WalChange> committedChanges = prepareCommittedWalChanges(changes);
+                String consumedLsn =
+                        walReplicationStream.isUseReplicationApi()
+                                ? streamLsn
+                                : lastCommittedWalLsn;
+                synchronized (ctx.getCheckpointLock()) {
+                    for (WalChange change : committedChanges) {
 
-                    // Filter out changes from non-target tables.
-                    // WAL logical decoding captures ALL changes in the database,
-                    // but we only want changes for tables matching the configured pattern.
-                    String changeSchema = change.getSchema();
-                    String changeTable = change.getTable();
-                    if (changeSchema == null || changeTable == null) {
-                        LOG.debug(
-                                "Skipping change with null schema/table: {}.{}",
-                                changeSchema,
-                                changeTable);
-                        continue;
-                    }
-                    if (!isTableMatch(changeSchema, changeTable)) {
-                        LOG.debug(
-                                "Skipping change from non-target table: {}.{}",
-                                changeSchema,
-                                changeTable);
-                        continue;
-                    }
+                        // Filter out changes from non-target tables.
+                        // WAL logical decoding captures ALL changes in the database,
+                        // but we only want changes for tables matching the configured pattern.
+                        String changeSchema = change.getSchema();
+                        String changeTable = change.getTable();
+                        if (changeSchema == null || changeTable == null) {
+                            LOG.debug(
+                                    "Skipping change with null schema/table: {}.{}",
+                                    changeSchema,
+                                    changeTable);
+                            continue;
+                        }
+                        if (!isTableMatch(changeSchema, changeTable)) {
+                            LOG.debug(
+                                    "Skipping change from non-target table: {}.{}",
+                                    changeSchema,
+                                    changeTable);
+                            continue;
+                        }
 
-                    // SQL fallback: skip changes at or before the last consumed LSN.
-                    // pg_logical_slot_peek_changes may return the same data
-                    // repeatedly if slot advancement is unavailable.
-                    if (lastConsumedLsn != null
-                            && change.getLsn() != null
-                            && !WalReplicationStream.isLsnNewer(change.getLsn(), lastConsumedLsn)) {
-                        LOG.info(
-                                "[DIAG] Filtered dup: change LSN={} <= lastConsumed={}, type={}, table={}",
-                                change.getLsn(),
-                                lastConsumedLsn,
-                                change.getType(),
-                                change.getTable());
-                        continue;
-                    }
-                    WalChange.ChangeType changeType = change.getType();
-                    RowData row = null;
-                    try {
-                        if ("json".equalsIgnoreCase(outputFormat)) {
-                            // JSON output mode: single STRING column with all data
-                            row = convertWalChangeToJson(change);
-                        } else {
-                            // Raw output mode: RowData with fixed columns per table
-                            if (changeType == WalChange.ChangeType.INSERT) {
-                                row =
-                                        convertWalColumnsToRowData(
-                                                change.getAfterColumns(), changeTable);
-                            } else if (changeType == WalChange.ChangeType.UPDATE) {
-                                row =
-                                        convertWalColumnsToRowData(
-                                                change.getAfterColumns(), changeTable);
-                            } else if (changeType == WalChange.ChangeType.DELETE) {
-                                row =
-                                        convertWalColumnsToRowData(
-                                                change.getBeforeColumns(), changeTable);
-                                if (row != null) {
-                                    row.setRowKind(RowKind.DELETE);
+                        // The replication API can replay individual WAL records from its start LSN.
+                        // SQL fallback is deduplicated at COMMIT granularity in
+                        // prepareCommittedWalChanges(): a transaction's data LSN may legitimately
+                        // be
+                        // older than lastConsumedLsn when its COMMIT arrives in a later read batch.
+                        if (walReplicationStream.isUseReplicationApi()
+                                && lastConsumedLsn != null
+                                && change.getLsn() != null
+                                && !WalReplicationStream.isLsnNewer(
+                                        change.getLsn(), lastConsumedLsn)) {
+                            LOG.info(
+                                    "[DIAG] Filtered dup: change LSN={} <= lastConsumed={}, type={}, table={}",
+                                    change.getLsn(),
+                                    lastConsumedLsn,
+                                    change.getType(),
+                                    change.getTable());
+                            continue;
+                        }
+                        WalChange.ChangeType changeType = change.getType();
+                        RowData row = null;
+                        try {
+                            if ("json".equalsIgnoreCase(outputFormat)) {
+                                // JSON output mode: single STRING column with all data
+                                row = convertWalChangeToJson(change);
+                            } else {
+                                // Raw output mode: RowData with fixed columns per table
+                                if (changeType == WalChange.ChangeType.INSERT) {
+                                    row =
+                                            convertWalColumnsToRowData(
+                                                    change.getAfterColumns(), changeTable);
+                                } else if (changeType == WalChange.ChangeType.UPDATE) {
+                                    row =
+                                            convertWalColumnsToRowData(
+                                                    change.getAfterColumns(), changeTable);
+                                } else if (changeType == WalChange.ChangeType.DELETE) {
+                                    row =
+                                            convertWalColumnsToRowData(
+                                                    change.getBeforeColumns(), changeTable);
+                                    if (row != null) {
+                                        row.setRowKind(RowKind.DELETE);
+                                    }
                                 }
                             }
+                        } catch (Exception e) {
+                            LOG.warn(
+                                    "Failed to convert WAL change on {}.{}: {}",
+                                    changeSchema,
+                                    changeTable,
+                                    e.getMessage());
+                            continue;
                         }
-                    } catch (Exception e) {
-                        LOG.warn(
-                                "Failed to convert WAL change on {}.{}: {}",
-                                changeSchema,
-                                changeTable,
-                                e.getMessage());
-                        continue;
+
+                        if (row != null) {
+                            ctx.collect(row);
+                            // Log first few emissions to correlate with LSN filter
+                            if (walEmitCount < 3) {
+                                LOG.info(
+                                        "[DIAG] Emitted #{}, type={}, LSN={}, row={}",
+                                        walEmitCount + 1,
+                                        changeType,
+                                        change.getLsn(),
+                                        row);
+                                walEmitCount++;
+                            }
+                        }
                     }
 
-                    if (row != null) {
-                        synchronized (ctx.getCheckpointLock()) {
-                            ctx.collect(row);
-                        }
-                        // Log first few emissions to correlate with LSN filter
-                        if (walEmitCount < 3) {
-                            LOG.info(
-                                    "[DIAG] Emitted #{}, type={}, LSN={}, row={}",
-                                    walEmitCount + 1,
-                                    changeType,
-                                    change.getLsn(),
-                                    row);
-                            walEmitCount++;
-                        }
+                    if (consumedLsn != null
+                            && (lastConsumedLsn == null
+                                    || WalReplicationStream.isLsnNewer(
+                                            consumedLsn, lastConsumedLsn))) {
+                        // Keep event emission and the corresponding source offset atomic with
+                        // Flink checkpoint snapshots. SQL fallback advances only through the
+                        // contiguous COMMIT prefix prepared above.
+                        lastConsumedLsn = consumedLsn;
                     }
                 }
 
@@ -686,6 +1265,125 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     }
 
     /**
+     * Return only transactionally committed SQL-fallback changes.
+     *
+     * <p>The logical slot is created immediately before exporting the MVCC snapshot. A transaction
+     * that commits between those two operations is therefore present in both the snapshot and WAL.
+     * GaussDB's exported CSN identifies exactly that overlap: transactions at or below the snapshot
+     * CSN are discarded, while later commits are emitted. Buffering until COMMIT also ensures that
+     * checkpoint offsets never split a transaction.
+     */
+    private List<WalChange> prepareCommittedWalChanges(List<WalChange> changes) {
+        if (changes.isEmpty() || walReplicationStream.isUseReplicationApi()) {
+            return changes;
+        }
+        if (pendingWalTransactions == null) {
+            pendingWalTransactions = new HashMap<>();
+        }
+        if (pendingWalTransactionOrder == null) {
+            pendingWalTransactionOrder = new ArrayDeque<>();
+        }
+
+        List<WalChange> committed = new ArrayList<>();
+        for (WalChange change : changes) {
+            if (change.getType() == WalChange.ChangeType.BEGIN) {
+                if (!pendingWalTransactions.containsKey(change.getXid())) {
+                    PendingWalTransaction transaction = new PendingWalTransaction(change.getXid());
+                    pendingWalTransactions.put(change.getXid(), transaction);
+                    pendingWalTransactionOrder.addLast(transaction);
+                }
+            } else if (change.isDataChange()) {
+                PendingWalTransaction transaction = pendingWalTransactions.get(change.getXid());
+                if (transaction == null) {
+                    // Keep compatibility with decoding formats that omit transaction markers,
+                    // while still preserving its order behind any unfinished transaction.
+                    transaction = new PendingWalTransaction(change.getXid());
+                    transaction.committed = true;
+                    transaction.commitLsn = change.getLsn();
+                    pendingWalTransactionOrder.addLast(transaction);
+                }
+                transaction.changes.add(change);
+                flushCommittedWalTransactions(committed);
+            } else if (change.getType() == WalChange.ChangeType.COMMIT) {
+                PendingWalTransaction transaction = pendingWalTransactions.get(change.getXid());
+                if (transaction == null) {
+                    LOG.debug(
+                            "COMMIT without buffered data (empty or replayed transaction): xid={}, lsn={}, pendingXids={}",
+                            change.getXid(),
+                            change.getLsn(),
+                            pendingWalTransactions.keySet());
+                    if (pendingWalTransactionOrder.isEmpty()) {
+                        advanceLastCommittedWalLsn(change.getLsn());
+                    }
+                    continue;
+                }
+                transaction.committed = true;
+                transaction.commitLsn = change.getLsn();
+                transaction.commitCsn = change.getCsn();
+                flushCommittedWalTransactions(committed);
+            }
+        }
+        return committed;
+    }
+
+    /**
+     * Release only the contiguous committed prefix of the decoded transaction stream.
+     *
+     * <p>GaussDB parallel logical decoding can return a later transaction's COMMIT while an older
+     * transaction is still incomplete. Emitting or checkpointing that later transaction would let
+     * recovery skip the older one. Keeping the ordered prefix here makes both event emission and
+     * the SQL slot watermark transaction-safe across read batches.
+     */
+    private void flushCommittedWalTransactions(List<WalChange> output) {
+        while (!pendingWalTransactionOrder.isEmpty()) {
+            PendingWalTransaction transaction = pendingWalTransactionOrder.peekFirst();
+            if (!transaction.committed) {
+                return;
+            }
+
+            pendingWalTransactionOrder.removeFirst();
+            pendingWalTransactions.remove(transaction.xid, transaction);
+
+            boolean replayedTransaction =
+                    lastConsumedLsn != null
+                            && transaction.commitLsn != null
+                            && !WalReplicationStream.isLsnNewer(
+                                    transaction.commitLsn, lastConsumedLsn);
+            boolean visibleInSnapshot =
+                    snapshotCsn >= 0
+                            && transaction.commitCsn > 0
+                            && transaction.commitCsn <= snapshotCsn;
+
+            if (visibleInSnapshot) {
+                LOG.info(
+                        "Discarding {} WAL changes already visible in snapshot: xid={}, commitLsn={}, commitCsn={}, snapshotCsn={}",
+                        transaction.changes.size(),
+                        transaction.xid,
+                        transaction.commitLsn,
+                        transaction.commitCsn,
+                        snapshotCsn);
+            } else if (replayedTransaction) {
+                LOG.debug(
+                        "Discarding replayed WAL transaction: xid={}, commitLsn={}, lastConsumedLsn={}",
+                        transaction.xid,
+                        transaction.commitLsn,
+                        lastConsumedLsn);
+            } else {
+                output.addAll(transaction.changes);
+            }
+            advanceLastCommittedWalLsn(transaction.commitLsn);
+        }
+    }
+
+    private void advanceLastCommittedWalLsn(String candidate) {
+        if (candidate != null
+                && (lastCommittedWalLsn == null
+                        || WalReplicationStream.isLsnNewer(candidate, lastCommittedWalLsn))) {
+            lastCommittedWalLsn = candidate;
+        }
+    }
+
+    /**
      * Reconnect to GaussDB and re-establish the WAL replication stream.
      *
      * <p>Called when the WAL streaming loop encounters a connection error (e.g. database restart).
@@ -694,11 +1392,13 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
      * duplicate data.
      */
     private void reconnectWalStream() throws Exception {
-        // Save the last known LSN before closing
-        String resumeLsn = walReplicationStream != null ? walReplicationStream.getLastLsn() : null;
+        String lastReadLsn =
+                walReplicationStream != null ? walReplicationStream.getLastLsn() : null;
         LOG.info(
-                "Reconnecting WAL stream, last known LSN: {}",
-                resumeLsn != null ? resumeLsn : "unknown");
+                "Reconnecting WAL stream, lastReadLsn={}, lastSafeLsn={}, lastAcknowledgedLsn={}",
+                lastReadLsn,
+                lastConsumedLsn,
+                lastAcknowledgedLsn);
 
         // Close old WAL stream (may be broken)
         if (walReplicationStream != null) {
@@ -724,11 +1424,15 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
 
         // Re-establish JDBC connection
         Class.forName("com.huawei.gaussdb.jdbc.Driver");
-        String url =
-                String.format(
-                        "jdbc:gaussdb://%s:%d/%s?sslmode=%s", hostname, port, database, sslMode);
+        String url = buildJdbcUrl();
         connection = DriverManager.getConnection(url, username, password);
+        identifierQuoteString = SqlIdentifierUtils.resolveQuoteString(connection);
         LOG.info("Reconnected JDBC to {}:{}/{}", hostname, port, database);
+
+        // A reconnect does not make a fixed Flink RowType capable of schema evolution. Verify the
+        // metadata instead of silently retaining stale column/PK positions or clearing the caches
+        // and emitting rows with a different arity.
+        validateCachedTableMetadataAfterReconnect();
 
         // Re-create WAL stream
         walReplicationStream =
@@ -742,17 +1446,20 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                         parallelDecodeNum,
                         decodeStyle,
                         sendingBatch,
-                        1000,
+                        chunkSize,
                         replicationPort);
 
-        // Resume from last known position.
-        // The slot already exists (was created on first run), so mppdb_decoding
-        // will NOT emit a snapshot — we'll only get changes since the slot position.
-        if (resumeLsn != null) {
-            walReplicationStream.initialize(resumeLsn);
-        } else {
-            walReplicationStream.initialize();
+        // Re-read from the database slot's checkpoint-acknowledged position. Advancing to the last
+        // record merely read by the broken connection can skip a BEGIN/DELETE whose COMMIT had not
+        // arrived yet. Replayed committed transactions are filtered at COMMIT against
+        // lastConsumedLsn.
+        if (pendingWalTransactions != null) {
+            pendingWalTransactions.clear();
         }
+        if (pendingWalTransactionOrder != null) {
+            pendingWalTransactionOrder.clear();
+        }
+        walReplicationStream.initialize();
 
         LOG.info(
                 "WAL stream re-initialized, starting from LSN: {}",
@@ -761,34 +1468,37 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
 
     /** Phase 2b: Polling-based streaming using ChangeDataPoller. */
     private void runPollingStreaming(SourceContext<RowData> ctx) throws Exception {
-        if (changeDataPoller != null) {
+        if (changeDataPoller != null && restoredPollingState == null) {
             changeDataPoller.loadSnapshot();
         }
 
         while (running) {
-            List<ChangeEvent<RowData>> events = changeDataPoller.pollAllChanges();
+            List<ChangeEvent<RowData>> events;
+            // Poller cursors/snapshots and emitted rows must move atomically relative to a Flink
+            // checkpoint. This may delay a checkpoint for the duration of one polling query, but it
+            // does not lock source tables or block business DML.
+            synchronized (ctx.getCheckpointLock()) {
+                events = changeDataPoller.pollAllChanges();
+                for (ChangeEvent<RowData> event : events) {
+                    RowData row = null;
+                    switch (event.getChangeType()) {
+                        case INSERT:
+                        case UPDATE:
+                            row = event.getAfter();
+                            break;
+                        case DELETE:
+                            row = event.getBefore();
+                            if (row instanceof GenericRowData) {
+                                ((GenericRowData) row).setRowKind(RowKind.DELETE);
+                            }
+                            LOG.debug("Detected DELETE event");
+                            break;
+                        case SNAPSHOT:
+                            row = event.getAfter();
+                            break;
+                    }
 
-            for (ChangeEvent<RowData> event : events) {
-                RowData row = null;
-                switch (event.getChangeType()) {
-                    case INSERT:
-                    case UPDATE:
-                        row = event.getAfter();
-                        break;
-                    case DELETE:
-                        row = event.getBefore();
-                        if (row instanceof GenericRowData) {
-                            ((GenericRowData) row).setRowKind(RowKind.DELETE);
-                        }
-                        LOG.debug("Detected DELETE event");
-                        break;
-                    case SNAPSHOT:
-                        row = event.getAfter();
-                        break;
-                }
-
-                if (row != null) {
-                    synchronized (ctx.getCheckpointLock()) {
+                    if (row != null) {
                         ctx.collect(row);
                     }
                 }
@@ -803,11 +1513,23 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     @Override
     public void cancel() {
         running = false;
+        if (snapshotCoordinationActive && connection != null) {
+            try {
+                // Closing the session immediately releases GaussDB session advisory/table locks
+                // and unblocks the remaining snapshot subtasks during task cancellation.
+                connection.close();
+            } catch (SQLException e) {
+                LOG.debug("Failed to close snapshot connection during cancellation", e);
+            }
+        }
     }
 
     @Override
     public void close() throws Exception {
         running = false;
+        if (snapshotCoordinationActive) {
+            abortCoordinatedSnapshot();
+        }
         if (walReplicationStream != null) {
             walReplicationStream.close();
         }
@@ -817,78 +1539,31 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         }
     }
 
-    /**
-     * Read the replication slot's confirmed_flush position as the starting LSN for WAL streaming
-     * after snapshot. This avoids replaying WAL changes that occurred before the slot was created
-     * (which are already captured by the initial snapshot query).
-     *
-     * <p>Uses the slot's confirmed_flush rather than WAL control functions like
-     * pg_current_wal_lsn(), because GaussDB standby nodes cannot execute WAL control functions.
-     */
-    private String getSlotConfirmedFlush() throws SQLException {
-        // Always prefer the current WAL position over the slot's
-        // confirmed_flush. confirmed_flush lags behind (it reflects the
-        // last position that was acknowledged by a previous CDC run), so
-        // using it would cause WAL to replay data that was written after
-        // the previous run ended, which the snapshot already captured.
-        //
-        // Try pg_current_wal_lsn() / pg_current_xlog_location() first
-        // (different GaussDB versions use different function names).
-        // Fall back to confirmed_flush only on standby nodes where WAL
-        // control functions are unavailable.
-        String[] walFuncs = {"SELECT pg_current_wal_lsn()", "SELECT pg_current_xlog_location()"};
-        for (String walFunc : walFuncs) {
-            try {
-                try (Statement stmt = connection.createStatement();
-                        ResultSet rs = stmt.executeQuery(walFunc)) {
-                    if (rs.next()) {
-                        String lsn = rs.getString(1);
-                        if (lsn != null && !lsn.isEmpty()) {
-                            LOG.info("Using {} as WAL start LSN: {}", walFunc, lsn);
-                            return lsn;
-                        }
-                    }
-                }
-            } catch (SQLException e) {
-                LOG.debug("{} failed: {}", walFunc, e.getMessage());
-            }
-        }
-
-        // Fallback: standby nodes cannot execute WAL control functions.
-        // Read the slot's confirmed_flush as the next best position.
-        String slotToCheck = slotName;
-        String sql = "SELECT confirmed_flush FROM pg_replication_slots WHERE slot_name = ?";
-        try (PreparedStatement stmt = connection.prepareStatement(sql)) {
-            stmt.setString(1, slotToCheck);
-            try (ResultSet rs = stmt.executeQuery()) {
-                if (rs.next()) {
-                    String lsn = rs.getString("confirmed_flush");
-                    if (lsn != null && !lsn.isEmpty()) {
-                        LOG.info(
-                                "WAL functions unavailable, using slot confirmed_flush: {} (slot={})",
-                                lsn,
-                                slotToCheck);
-                        return lsn;
-                    }
-                }
-            }
-        }
-
-        LOG.warn("Could not determine WAL start position for slot '{}'", slotToCheck);
-        return null;
-    }
-
     // ---- CheckpointedFunction ----
 
     @Override
     public void snapshotState(FunctionSnapshotContext context) throws Exception {
         offsetState.clear();
+        if (pollingState != null) {
+            pollingState.clear();
+        }
         if (walReplicationStream != null && walStreamInitialized) {
-            String lsn = walReplicationStream.getLastLsn();
+            String lsn =
+                    lastConsumedLsn != null ? lastConsumedLsn : walReplicationStream.getLastLsn();
             if (lsn != null) {
                 offsetState.add(lsn);
+                if (pendingCheckpointLsns == null) {
+                    pendingCheckpointLsns = new TreeMap<>();
+                }
+                pendingCheckpointLsns.put(context.getCheckpointId(), lsn);
                 LOG.debug("Checkpointed LSN: {}", lsn);
             }
+        } else if (!walMode
+                && changeDataPoller != null
+                && pollingState != null
+                && getRuntimeContext().getIndexOfThisSubtask() == 0) {
+            pollingState.add(changeDataPoller.serializeState());
+            LOG.debug("Checkpointed polling CDC state");
         }
     }
 
@@ -896,13 +1571,58 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
     public void initializeState(FunctionInitializationContext context) throws Exception {
         ListStateDescriptor<String> descriptor =
                 new ListStateDescriptor<>("gaussdb-cdc-offset-state", Types.STRING);
-        offsetState = context.getOperatorStateStore().getListState(descriptor);
+        // Union state makes the single WAL offset available to the new subtask 0 after rescaling.
+        offsetState = context.getOperatorStateStore().getUnionListState(descriptor);
+        ListStateDescriptor<byte[]> pollingDescriptor =
+                new ListStateDescriptor<>(
+                        "gaussdb-cdc-polling-state",
+                        PrimitiveArrayTypeInfo.BYTE_PRIMITIVE_ARRAY_TYPE_INFO);
+        // Only polling subtask 0 writes this state. Union distribution guarantees that the new
+        // subtask 0 receives it after rescaling.
+        pollingState = context.getOperatorStateStore().getUnionListState(pollingDescriptor);
+        pendingCheckpointLsns = new TreeMap<>();
 
         if (context.isRestored()) {
-            // Restore LSN from checkpoint (for future use with LSN-based resumption)
             for (String lsn : offsetState.get()) {
+                restoredLsn = lsn;
                 LOG.info("Restored LSN from checkpoint: {}", lsn);
+                break;
             }
+            if (!walMode && pollingState != null) {
+                for (byte[] state : pollingState.get()) {
+                    restoredPollingState = state;
+                    LOG.info("Restored polling CDC state from checkpoint");
+                    break;
+                }
+            }
+        }
+    }
+
+    @Override
+    public void notifyCheckpointComplete(long checkpointId) throws Exception {
+        if (walReplicationStream == null
+                || !walStreamInitialized
+                || pendingCheckpointLsns == null) {
+            return;
+        }
+        Map.Entry<Long, String> completed = pendingCheckpointLsns.floorEntry(checkpointId);
+        if (completed != null) {
+            if (!completed.getValue().equals(lastAcknowledgedLsn)) {
+                walReplicationStream.acknowledgeLsn(completed.getValue());
+                lastAcknowledgedLsn = completed.getValue();
+                LOG.info(
+                        "Acknowledged WAL LSN {} after Flink checkpoint {} completed",
+                        completed.getValue(),
+                        checkpointId);
+            }
+            pendingCheckpointLsns.headMap(checkpointId, true).clear();
+        }
+    }
+
+    @Override
+    public void notifyCheckpointAborted(long checkpointId) {
+        if (pendingCheckpointLsns != null) {
+            pendingCheckpointLsns.remove(checkpointId);
         }
     }
 
@@ -964,6 +1684,12 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         if (cachedColumnsByTable.containsKey(tbl)) {
             return;
         }
+        List<String> colNames = loadTableColumnNames(tbl);
+        cachedColumnsByTable.put(tbl, colNames);
+        LOG.info("Cached {} columns for table {}.{}: {}", colNames.size(), schema, tbl, colNames);
+    }
+
+    private List<String> loadTableColumnNames(String tbl) throws SQLException {
         DatabaseMetaData meta = connection.getMetaData();
         List<String> colNames = new ArrayList<>();
         try (ResultSet rs = meta.getColumns(null, schema, tbl, null)) {
@@ -971,8 +1697,69 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
                 colNames.add(rs.getString("COLUMN_NAME"));
             }
         }
-        cachedColumnsByTable.put(tbl, colNames);
-        LOG.info("Cached {} columns for table {}.{}: {}", colNames.size(), schema, tbl, colNames);
+        return colNames;
+    }
+
+    private String identifierQuoteString() throws SQLException {
+        if (identifierQuoteString == null) {
+            identifierQuoteString = SqlIdentifierUtils.resolveQuoteString(connection);
+        }
+        return identifierQuoteString;
+    }
+
+    private String quoteIdentifier(String identifier) throws SQLException {
+        return SqlIdentifierUtils.quote(identifier, identifierQuoteString());
+    }
+
+    private String qualifiedTable(String tbl) throws SQLException {
+        return SqlIdentifierUtils.qualified(schema, tbl, identifierQuoteString());
+    }
+
+    private String quoteColumnList(List<String> columns) throws SQLException {
+        return SqlIdentifierUtils.columnList(columns, identifierQuoteString());
+    }
+
+    /**
+     * Fail explicitly when a reconnect observes a table definition different from the cached one.
+     */
+    private void validateCachedTableMetadataAfterReconnect() throws SQLException {
+        if (cachedColumnsByTable != null) {
+            for (Map.Entry<String, List<String>> entry : cachedColumnsByTable.entrySet()) {
+                List<String> freshColumns = loadTableColumnNames(entry.getKey());
+                if (!entry.getValue().equals(freshColumns)) {
+                    throw schemaEvolutionException(
+                            entry.getKey(),
+                            "columns changed from " + entry.getValue() + " to " + freshColumns);
+                }
+            }
+        }
+        if (cachedPkByTable != null) {
+            for (Map.Entry<String, String> entry : cachedPkByTable.entrySet()) {
+                String freshPk = detectPrimaryKeyColumn(entry.getKey());
+                if (!entry.getValue().equals(freshPk)) {
+                    throw schemaEvolutionException(
+                            entry.getKey(),
+                            "primary key changed from " + entry.getValue() + " to " + freshPk);
+                }
+            }
+        }
+    }
+
+    private SQLException schemaEvolutionException(String tbl, String detail) {
+        return new SQLException(
+                "Unsupported schema change detected for "
+                        + qualifiedTableForMessage(tbl)
+                        + " after WAL reconnect: "
+                        + detail
+                        + ". Cancel the job, update the Flink table schema, and restart it.");
+    }
+
+    private String qualifiedTableForMessage(String tbl) {
+        try {
+            return qualifiedTable(tbl);
+        } catch (SQLException ignored) {
+            return schema + "." + tbl;
+        }
     }
 
     private String getTableColumns(String tbl) throws SQLException {
@@ -984,7 +1771,7 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         if (cols == null || cols.isEmpty()) {
             throw new SQLException("No columns found for table " + schema + "." + tbl);
         }
-        return String.join(", ", cols);
+        return quoteColumnList(cols);
     }
 
     /**
@@ -1047,12 +1834,12 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
      * Convert a WalChange to a single-column RowData containing a JSON string. Used in
      * output.format=json mode for heterogeneous multi-table capture.
      *
-     * <p>JSON format (aligned with Haier CDC extraction structure):
+     * <p>Custom JSON format selected by {@code output.json.format=he}:
      *
      * <pre>
      * {
      *   "database": "event_driven",
-     *   "table": "haier_cbs_order_oper",
+     *   "table": "sample_order_oper",
      *   "optType": "INSERT",
      *   "pkNames": ["id"],
      *   "pkValues": "722253",
@@ -1070,8 +1857,8 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         String json;
         if ("canal".equalsIgnoreCase(outputJsonFormat)) {
             json = buildCanalJson(change);
-        } else if ("haier".equalsIgnoreCase(outputJsonFormat)) {
-            json = buildHaierJson(change);
+        } else if ("he".equalsIgnoreCase(outputJsonFormat)) {
+            json = buildCustomJson(change);
         } else {
             json = buildDebeziumJson(change);
         }
@@ -1183,15 +1970,15 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         return sb.toString();
     }
 
-    /** Build Haier customized Canal JSON format. */
-    private String buildHaierJson(WalChange change) {
+    /** Build the custom Canal-compatible JSON format. */
+    private String buildCustomJson(WalChange change) {
         StringBuilder sb = new StringBuilder(512);
         sb.append('{');
         // database
         sb.append("\"database\":\"").append(escapeJson(database)).append('"');
         // table
         sb.append(",\"table\":\"").append(escapeJson(change.getTable())).append('"');
-        // optType (haier uses optType instead of type)
+        // Custom envelope uses optType instead of Canal's type field.
         sb.append(",\"optType\":\"").append(change.getType().name()).append('"');
         // pkNames + pkValues
         String tbl = change.getTable();
@@ -1330,8 +2117,8 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             String json;
             if ("canal".equalsIgnoreCase(outputJsonFormat)) {
                 json = buildCanalSnapshotJson(rs, meta, tbl);
-            } else if ("haier".equalsIgnoreCase(outputJsonFormat)) {
-                json = buildHaierSnapshotJson(rs, meta, tbl);
+            } else if ("he".equalsIgnoreCase(outputJsonFormat)) {
+                json = buildCustomSnapshotJson(rs, meta, tbl);
             } else {
                 json = buildDebeziumSnapshotJson(rs, meta, tbl);
             }
@@ -1398,8 +2185,8 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         return sb.toString();
     }
 
-    /** Build Haier JSON for snapshot row (optType=INSERT). */
-    private String buildHaierSnapshotJson(ResultSet rs, ResultSetMetaData meta, String tbl)
+    /** Build custom JSON for a snapshot row (optType=INSERT). */
+    private String buildCustomSnapshotJson(ResultSet rs, ResultSetMetaData meta, String tbl)
             throws SQLException {
         String pkCol = null;
         if (cachedPkByTable != null) {
@@ -1585,7 +2372,6 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
         private String username;
         private String password;
         private String slotName = "flink_cdc_slot";
-        private String pluginName = "mppdb_decoding";
         private boolean snapshotMode = true;
         private int chunkSize = 1000;
         private int connectTimeoutMs = 30000;
@@ -1640,8 +2426,10 @@ public class GaussDBCDCSourceFunction extends RichSourceFunction<RowData>
             return this;
         }
 
+        /** @deprecated Use {@link #decodePlugin(String)}. */
+        @Deprecated
         public Builder pluginName(String pluginName) {
-            this.pluginName = pluginName;
+            this.decodePlugin = pluginName;
             return this;
         }
 

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/SqlIdentifierUtils.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/SqlIdentifierUtils.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.gaussdbcdc.source;
+
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Utilities for safely embedding GaussDB identifiers in SQL text. */
+final class SqlIdentifierUtils {
+
+    private SqlIdentifierUtils() {}
+
+    /**
+     * Resolve the quote used by the current GaussDB compatibility mode.
+     *
+     * <p>The GaussDB JDBC driver reports a double quote even for an M-compatible database, while
+     * that mode accepts MySQL-style backticks for identifiers. Check the server mode first and use
+     * JDBC metadata for other modes.
+     */
+    static String resolveQuoteString(Connection connection) throws SQLException {
+        try (Statement stmt = connection.createStatement()) {
+            if (stmt != null) {
+                try (ResultSet rs = stmt.executeQuery("SHOW sql_compatibility")) {
+                    if (rs != null && rs.next() && "M".equalsIgnoreCase(rs.getString(1))) {
+                        return "`";
+                    }
+                }
+            }
+        } catch (SQLException ignored) {
+            // Standard PostgreSQL and some GaussDB variants do not expose sql_compatibility.
+        }
+        DatabaseMetaData metadata = connection.getMetaData();
+        if (metadata == null) {
+            return "\"";
+        }
+        String quote = metadata.getIdentifierQuoteString();
+        return quote == null || quote.trim().isEmpty() ? "\"" : quote;
+    }
+
+    /** Quote one identifier. Embedded quote characters are escaped per the SQL standard. */
+    static String quote(String identifier) {
+        return quote(identifier, "\"");
+    }
+
+    static String quote(String identifier, String quoteString) {
+        if (identifier == null) {
+            throw new IllegalArgumentException("SQL identifier must not be null");
+        }
+        if (quoteString == null || quoteString.isEmpty()) {
+            throw new IllegalArgumentException("SQL identifier quote must not be empty");
+        }
+        return quoteString
+                + identifier.replace(quoteString, quoteString + quoteString)
+                + quoteString;
+    }
+
+    /** Quote a schema-qualified table name, treating both parts as separate identifiers. */
+    static String qualified(String schema, String table) {
+        return qualified(schema, table, "\"");
+    }
+
+    static String qualified(String schema, String table, String quoteString) {
+        return quote(schema, quoteString) + "." + quote(table, quoteString);
+    }
+
+    /** Quote each column separately before building a SELECT list. */
+    static String columnList(List<String> columns) {
+        return columnList(columns, "\"");
+    }
+
+    static String columnList(List<String> columns, String quoteString) {
+        return columns.stream()
+                .map(column -> quote(column, quoteString))
+                .collect(Collectors.joining(", "));
+    }
+}

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/wal/WalReplicationStream.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/source/wal/WalReplicationStream.java
@@ -81,7 +81,9 @@ public class WalReplicationStream {
     private String lastLsn;
     private boolean running = false;
     private boolean useReplicationApi = false;
-    private boolean firstSqlRead = true;
+    // SQL peek does not move the server slot. Keep the LSN of every row read since the last
+    // completed checkpoint so later peeks can skip that prefix while still retaining it for replay.
+    private final List<String> sqlUnacknowledgedLsns = new ArrayList<>();
 
     private final MppdbBinaryDecoder binaryDecoder;
 
@@ -154,6 +156,23 @@ public class WalReplicationStream {
     }
 
     /**
+     * Ensure that the logical slot exists before a JDBC snapshot starts and return its WAL
+     * position. Creating the slot before the SELECT snapshot is essential: otherwise WAL generated
+     * while the snapshot is running is not retained and can be lost at the snapshot/stream handoff.
+     */
+    public String prepareSlotForSnapshot() throws SQLException {
+        String slotLsn = null;
+        if (!slotExists()) {
+            slotLsn = createSlot();
+        }
+        if (slotLsn == null || slotLsn.isEmpty()) {
+            slotLsn = getCurrentLsn();
+        }
+        LOG.info("Prepared replication slot '{}' for snapshot at LSN {}", slotName, slotLsn);
+        return slotLsn;
+    }
+
+    /**
      * Initialize the replication stream with a specific starting LSN.
      *
      * <p>After an initial snapshot has been taken, pass the LSN recorded just before the snapshot
@@ -172,15 +191,10 @@ public class WalReplicationStream {
                 sendingBatch,
                 startLsn);
 
-        // Check if slot exists; track whether we just created it.
-        // When a new slot is created and the JDBC replication API is used,
-        // mppdb_decoding emits a full consistency snapshot (snapbuild) as
-        // its first output batch. We consume and discard this snapshot below
-        // to avoid duplicating data already captured by the JDBC snapshot.
-        boolean slotWasNew = false;
+        // The source normally prepares the slot before taking a JDBC snapshot so that changes
+        // committed during the snapshot are retained. Keep this fallback for streaming-only mode.
         if (!slotExists()) {
             createSlot();
-            slotWasNew = true;
         }
 
         // Use the provided startLsn instead of always starting from "0/0".
@@ -203,28 +217,6 @@ public class WalReplicationStream {
                     "JDBC replication API not available, falling back to SQL function polling: {}",
                     e.getMessage());
             useReplicationApi = false;
-            firstSqlRead = true;
-        }
-
-        // When a new slot is created and the JDBC replication API is active,
-        // mppdb_decoding's first output batch is a full consistency snapshot of
-        // all current table data. Since the caller already performed a JDBC
-        // snapshot (SELECT *), this data would be duplicated. Consume and
-        // discard it now so downstream only sees incremental changes.
-        if (slotWasNew && useReplicationApi) {
-            try {
-                int consumed = consumeInitialSnapshot();
-                LOG.info(
-                        "Consumed {} mppdb_decoding snapshot changes from new slot '{}'",
-                        consumed,
-                        slotName);
-            } catch (Exception e) {
-                LOG.warn(
-                        "Failed to consume initial mppdb_decoding snapshot for slot '{}' "
-                                + "(duplicate data may appear): {}",
-                        slotName,
-                        e.getMessage());
-            }
         }
 
         // SQL function fallback path: pg_logical_slot_peek_changes(NULL, ...)
@@ -234,7 +226,7 @@ public class WalReplicationStream {
         // read only picks up changes after the snapshot position.
         if (!useReplicationApi && !"0/0".equals(startLsn)) {
             try {
-                advanceSlot();
+                advanceSlot(startLsn);
                 LOG.info(
                         "Advanced slot '{}' to snapshot LSN {} for SQL function polling",
                         slotName,
@@ -248,41 +240,6 @@ public class WalReplicationStream {
         }
 
         running = true;
-    }
-
-    /**
-     * Read and discard the initial consistency snapshot emitted by mppdb_decoding when a brand-new
-     * replication slot starts streaming.
-     *
-     * @return number of snapshot changes consumed and discarded
-     */
-    private int consumeInitialSnapshot() throws SQLException {
-        LOG.debug("Reading initial mppdb_decoding snapshot data from new slot '{}'...", slotName);
-
-        // The JDBC replication stream may not have data available immediately
-        // after start(). Retry a few times with delays to catch the snapshot
-        // batch before the main read loop picks it up.
-        int totalConsumed = 0;
-        for (int attempt = 0; attempt < 5; attempt++) {
-            List<WalChange> batch = readChanges(10000);
-            if (batch.isEmpty()) {
-                // No data yet — wait and retry
-                try {
-                    Thread.sleep(200);
-                } catch (InterruptedException e) {
-                    Thread.currentThread().interrupt();
-                    break;
-                }
-                continue;
-            }
-            totalConsumed += batch.size();
-            // Snapshot data typically arrives in one batch; if we got data,
-            // we're done.
-            break;
-        }
-
-        LOG.debug("Discarded {} snapshot changes from slot '{}'", totalConsumed, slotName);
-        return totalConsumed;
     }
 
     /**
@@ -432,7 +389,7 @@ public class WalReplicationStream {
      * @param maxChanges maximum number of changes to read
      * @return list of WAL changes
      */
-    public List<WalChange> readChanges(int maxChanges) throws SQLException {
+    public synchronized List<WalChange> readChanges(int maxChanges) throws SQLException {
         if (useReplicationApi) {
             return readChangesFromReplicationApi(maxChanges);
         } else {
@@ -521,6 +478,14 @@ public class WalReplicationStream {
                 byte[] data = new byte[buffer.remaining()];
                 buffer.get(data);
 
+                // Capture the receive LSN for this replication record before decoding it. Serial
+                // mppdb_decoding records do not embed an LSN in their JSON/text payload, so using
+                // the previous value of lastLsn would make the first valid record look stale.
+                String recordLsn = getLastReceiveLsn();
+                if (recordLsn == null) {
+                    recordLsn = lastLsn;
+                }
+
                 // Decode the batch based on the actual output format.
                 // When parallelDecodeNum > 1, mppdb_decoding outputs in the format
                 // specified by decode-style (b=binary, j=json, t=text).
@@ -533,11 +498,14 @@ public class WalReplicationStream {
                 if (parallelDecodeNum > 1 && "b".equals(decodeStyle)) {
                     // Binary format: use MppdbBinaryDecoder
                     batchChanges = binaryDecoder.decodeBatch(data);
+                } else if (parallelDecodeNum > 1 && "j".equals(decodeStyle)) {
+                    // Parallel JSON mode may frame multiple JSON objects in one replication batch.
+                    batchChanges = parseJsonBatch(data, recordLsn);
                 } else {
                     // JSON/text format: parse each record individually.
                     // mppdb_decoding serial mode outputs one record per readPending()
                     // call (BEGIN, COMMIT as text; INSERT/UPDATE/DELETE as JSON).
-                    batchChanges = parseReplicationRecord(data);
+                    batchChanges = parseReplicationRecord(data, recordLsn);
                 }
 
                 changes.addAll(batchChanges);
@@ -552,15 +520,13 @@ public class WalReplicationStream {
 
                 // Also try to get LSN directly from the stream (more reliable
                 // for flow control than extracting from decoded data)
-                String streamLsn = getLastReceiveLsn();
+                String streamLsn = recordLsn;
                 if (streamLsn != null) {
                     lastLsn = streamLsn;
                 }
 
-                // Update flushed LSN on the stream to acknowledge processing
-                updateFlushedLsn(lastLsn);
-
-                // Force status update so the server can send more batches
+                // Keep the replication connection alive, but acknowledge applied/flushed LSNs only
+                // after a completed Flink checkpoint via acknowledgeLsn().
                 forceUpdateStatusMethod.invoke(replicationStream);
 
                 if (batchCount >= 100) {
@@ -614,7 +580,7 @@ public class WalReplicationStream {
      * determine when it can send more data. Without updating this, the server stops sending after a
      * few batches.
      */
-    private void updateFlushedLsn(String lsn) {
+    private void updateFlushedLsn(String lsn) throws SQLException {
         try {
             Class<?> lsnClass =
                     Class.forName(
@@ -628,7 +594,7 @@ public class WalReplicationStream {
                     replicationStream.getClass().getMethod("setFlushedLSN", lsnClass);
             setFlushedLSN.invoke(replicationStream, lsnObj);
         } catch (Exception e) {
-            LOG.debug("Could not update flushed LSN: {}", e.getMessage());
+            throw new SQLException("Could not update flushed LSN " + lsn, e);
         }
     }
 
@@ -650,6 +616,10 @@ public class WalReplicationStream {
      * @return list of parsed WalChange records (usually 1, may be empty for non-data records)
      */
     private List<WalChange> parseReplicationRecord(byte[] data) {
+        return parseReplicationRecord(data, lastLsn);
+    }
+
+    private List<WalChange> parseReplicationRecord(byte[] data, String recordLsn) {
         List<WalChange> changes = new ArrayList<>();
         if (data == null || data.length == 0) {
             return changes;
@@ -662,7 +632,7 @@ public class WalReplicationStream {
 
         // Delegate to parseChangeData which handles all formats:
         // BEGIN, COMMIT (text), JSON objects ({...}), and text-style changes (INSERT: ...)
-        WalChange change = parseChangeData(lastLsn, 0, text);
+        WalChange change = parseChangeData(recordLsn, 0, text);
         if (change != null) {
             changes.add(change);
         }
@@ -679,6 +649,10 @@ public class WalReplicationStream {
      * BEGIN/COMMIT markers.
      */
     private List<WalChange> parseJsonBatch(byte[] data) {
+        return parseJsonBatch(data, lastLsn);
+    }
+
+    private List<WalChange> parseJsonBatch(byte[] data, String recordLsn) {
         List<WalChange> changes = new ArrayList<>();
         String content = new String(data, java.nio.charset.StandardCharsets.UTF_8);
 
@@ -707,7 +681,7 @@ public class WalReplicationStream {
             }
             if (depth == 0) {
                 String jsonStr = content.substring(jsonStart, jsonEnd + 1);
-                WalChange change = parseChangeData(lastLsn, 0, jsonStr);
+                WalChange change = parseChangeData(recordLsn, 0, jsonStr);
                 if (change != null) {
                     changes.add(change);
                 }
@@ -739,34 +713,32 @@ public class WalReplicationStream {
             // For SQL function mode, parallel-decode-num alone controls parallelism.
         }
 
-        // On the first read after initialization, pass the snapshot start LSN
-        // instead of NULL. This skips WAL records already captured by the JDBC
-        // snapshot. pg_logical_slot_peek_changes with a specific LSN may return
-        // empty after pg_replication_slot_advance() on some GaussDB versions,
-        // so we only use this on the first call and fall back to NULL afterwards.
-        String startLsnArg;
-        if (firstSqlRead && !"0/0".equals(lastLsn)) {
-            startLsnArg = "'" + lastLsn + "'";
-            firstSqlRead = false;
-            LOG.info(
-                    "First SQL read: passing start LSN {} to pg_logical_slot_peek_changes",
-                    lastLsn);
-        } else {
-            startLsnArg = "NULL";
-        }
+        // GaussDB follows PostgreSQL's peek signature: the LSN argument is an upper bound, not a
+        // start position. Keep it NULL and request the already-read prefix plus one new page. The
+        // prefix remains on the server until a Flink checkpoint acknowledges it.
+        int alreadyRead = sqlUnacknowledgedLsns.size();
+        int queryLimit = (int) Math.min((long) Integer.MAX_VALUE, (long) alreadyRead + maxChanges);
 
         String sql =
                 String.format(
                         "SELECT location AS lsn, xid, data FROM pg_logical_slot_peek_changes(?, %s, ?, %s)",
-                        startLsnArg, optionBuilder);
+                        "NULL", optionBuilder);
 
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
+            stmt.setFetchSize(fetchSize);
             stmt.setString(1, slotName);
-            stmt.setInt(2, maxChanges);
+            stmt.setInt(2, queryLimit);
 
             try (ResultSet rs = stmt.executeQuery()) {
+                int rowIndex = 0;
                 while (rs.next()) {
+                    rowIndex++;
                     String lsn = rs.getString("lsn");
+                    if (rowIndex <= alreadyRead) {
+                        continue;
+                    }
+                    sqlUnacknowledgedLsns.add(lsn);
+                    lastLsn = lsn;
                     long xid = rs.getLong("xid");
                     String data = rs.getString("data");
 
@@ -779,15 +751,9 @@ public class WalReplicationStream {
                         if (change != null) {
                             changes.add(change);
                         }
-                        lastLsn = lsn;
                     }
                 }
             }
-        }
-
-        // Advance the slot position after peeking
-        if (!changes.isEmpty()) {
-            advanceSlot();
         }
 
         return changes;
@@ -800,25 +766,37 @@ public class WalReplicationStream {
      * pg_logical_slot_advance(). This method tries both for compatibility.
      */
     private void advanceSlot() throws SQLException {
-        if (lastLsn == null) {
+        advanceSlot(lastLsn);
+    }
+
+    private void advanceSlot(String targetLsn) throws SQLException {
+        if (targetLsn == null) {
             return;
         }
         // Try GaussDB compatible function first, then PostgreSQL function
         String[] sqlCandidates = {
             "SELECT pg_replication_slot_advance(?, ?)", "SELECT pg_logical_slot_advance(?, ?)"
         };
+        SQLException lastFailure = null;
         for (String sql : sqlCandidates) {
             try (PreparedStatement stmt = connection.prepareStatement(sql)) {
                 stmt.setString(1, slotName);
-                stmt.setString(2, lastLsn);
+                stmt.setString(2, targetLsn);
                 stmt.execute();
-                LOG.debug("Advanced slot {} to {} via {}", slotName, lastLsn, sql);
+                LOG.debug("Advanced slot {} to {} via {}", slotName, targetLsn, sql);
                 return;
             } catch (SQLException e) {
+                lastFailure = e;
                 LOG.debug("Advance function not available: {} - {}", sql, e.getMessage());
             }
         }
-        LOG.warn("Could not advance slot {} - no compatible function found", slotName);
+        throw new SQLException(
+                "Could not advance replication slot "
+                        + slotName
+                        + " to "
+                        + targetLsn
+                        + ": no compatible advance function succeeded",
+                lastFailure);
     }
 
     /**
@@ -1114,17 +1092,29 @@ public class WalReplicationStream {
     }
 
     /** Create a new logical replication slot with mppdb_decoding plugin. */
-    private void createSlot() throws SQLException {
+    private String createSlot() throws SQLException {
         LOG.info("Creating logical replication slot: {} with plugin: {}", slotName, pluginName);
 
-        String sql = "SELECT pg_create_logical_replication_slot(?, ?)";
+        String sql = "SELECT * FROM pg_create_logical_replication_slot(?, ?)";
         try (PreparedStatement stmt = connection.prepareStatement(sql)) {
             stmt.setString(1, slotName);
             stmt.setString(2, pluginName);
-            stmt.execute();
+            if (stmt.execute()) {
+                try (ResultSet rs = stmt.getResultSet()) {
+                    if (rs != null && rs.next()) {
+                        String createdAt = rs.getString(2);
+                        LOG.info(
+                                "Successfully created replication slot '{}' at LSN {}",
+                                slotName,
+                                createdAt);
+                        return createdAt;
+                    }
+                }
+            }
         }
 
         LOG.info("Successfully created replication slot: {}", slotName);
+        return null;
     }
 
     /**
@@ -1153,6 +1143,44 @@ public class WalReplicationStream {
             }
         }
         return "0/0";
+    }
+
+    /** Return the database WAL position used as a coordinated snapshot boundary. */
+    public String getCurrentLsnPosition() throws SQLException {
+        return getCurrentLsn();
+    }
+
+    /**
+     * Acknowledge an LSN after the corresponding Flink checkpoint completes.
+     *
+     * <p>SQL fallback advances the logical slot here rather than after every peek. The replication
+     * API similarly delays its flushed position, so a task restored from the latest completed
+     * checkpoint can replay every uncommitted record.
+     */
+    public synchronized void acknowledgeLsn(String lsn) throws SQLException {
+        if (lsn == null || "0/0".equals(lsn)) {
+            return;
+        }
+        if (useReplicationApi && replicationStream != null) {
+            updateFlushedLsn(lsn);
+            try {
+                Method forceUpdateStatus =
+                        replicationStream.getClass().getMethod("forceUpdateStatus");
+                forceUpdateStatus.invoke(replicationStream);
+            } catch (Exception e) {
+                throw new SQLException("Failed to acknowledge replication LSN " + lsn, e);
+            }
+        } else {
+            advanceSlot(lsn);
+            int acknowledged = 0;
+            while (acknowledged < sqlUnacknowledgedLsns.size()
+                    && !isLsnNewer(sqlUnacknowledgedLsns.get(acknowledged), lsn)) {
+                acknowledged++;
+            }
+            if (acknowledged > 0) {
+                sqlUnacknowledgedLsns.subList(0, acknowledged).clear();
+            }
+        }
     }
 
     /** Drop the replication slot. */

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSource.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSource.java
@@ -48,6 +48,8 @@ public class GaussDBCDCTableSource implements ScanTableSource {
     private final String sslMode;
     /** Optional dedicated port for WAL replication streaming; null = reuse {@link #port}. */
     private final Integer replicationPort;
+    /** Output format: "raw" (default, RowData) or "json" (single STRING column). */
+    private final String outputFormat;
 
     private final DataType physicalRowDataType;
 
@@ -69,6 +71,7 @@ public class GaussDBCDCTableSource implements ScanTableSource {
             boolean sendingBatch,
             String sslMode,
             Integer replicationPort,
+            String outputFormat,
             DataType physicalRowDataType) {
         this.hostname = hostname;
         this.port = port;
@@ -87,6 +90,7 @@ public class GaussDBCDCTableSource implements ScanTableSource {
         this.sendingBatch = sendingBatch;
         this.sslMode = sslMode;
         this.replicationPort = replicationPort;
+        this.outputFormat = outputFormat;
         this.physicalRowDataType = physicalRowDataType;
     }
 
@@ -116,6 +120,7 @@ public class GaussDBCDCTableSource implements ScanTableSource {
                         .sendingBatch(sendingBatch)
                         .sslMode(sslMode)
                         .replicationPort(replicationPort)
+                        .outputFormat(outputFormat)
                         .build();
 
         // SourceFunctionProvider is available since Flink 1.11, compatible with 1.13~1.17
@@ -142,6 +147,7 @@ public class GaussDBCDCTableSource implements ScanTableSource {
                 sendingBatch,
                 sslMode,
                 replicationPort,
+                outputFormat,
                 physicalRowDataType);
     }
 

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSource.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSource.java
@@ -39,6 +39,8 @@ public class GaussDBCDCTableSource implements ScanTableSource {
     private final String password;
     private final String slotName;
     private final boolean snapshotMode;
+    private final int chunkSize;
+    private final int connectTimeoutMs;
     private final int pollIntervalMs;
     private final boolean walMode;
     private final String decodePlugin;
@@ -50,11 +52,12 @@ public class GaussDBCDCTableSource implements ScanTableSource {
     private final Integer replicationPort;
     /** Output format: "raw" (default, RowData) or "json" (single STRING column). */
     private final String outputFormat;
-    /** JSON sub-format: "debezium" (default), "canal", or "haier". */
+    /** JSON sub-format: "debezium" (default), "canal", or "he". */
     private final String outputJsonFormat;
 
     private final DataType physicalRowDataType;
 
+    /** Backward-compatible constructor using the historical fetch and connection defaults. */
     public GaussDBCDCTableSource(
             String hostname,
             int port,
@@ -76,6 +79,54 @@ public class GaussDBCDCTableSource implements ScanTableSource {
             String outputFormat,
             String outputJsonFormat,
             DataType physicalRowDataType) {
+        this(
+                hostname,
+                port,
+                database,
+                schema,
+                tableName,
+                username,
+                password,
+                slotName,
+                snapshotMode,
+                1000,
+                30000,
+                pollIntervalMs,
+                walMode,
+                decodePlugin,
+                parallelDecodeNum,
+                decodeStyle,
+                sendingBatch,
+                sslMode,
+                replicationPort,
+                outputFormat,
+                outputJsonFormat,
+                physicalRowDataType);
+    }
+
+    public GaussDBCDCTableSource(
+            String hostname,
+            int port,
+            String database,
+            String schema,
+            String tableName,
+            String username,
+            String password,
+            String slotName,
+            boolean snapshotMode,
+            int chunkSize,
+            int connectTimeoutMs,
+            int pollIntervalMs,
+            boolean walMode,
+            String decodePlugin,
+            int parallelDecodeNum,
+            String decodeStyle,
+            boolean sendingBatch,
+            String sslMode,
+            Integer replicationPort,
+            String outputFormat,
+            String outputJsonFormat,
+            DataType physicalRowDataType) {
         this.hostname = hostname;
         this.port = port;
         this.database = database;
@@ -85,6 +136,8 @@ public class GaussDBCDCTableSource implements ScanTableSource {
         this.password = password;
         this.slotName = slotName;
         this.snapshotMode = snapshotMode;
+        this.chunkSize = chunkSize;
+        this.connectTimeoutMs = connectTimeoutMs;
         this.pollIntervalMs = pollIntervalMs;
         this.walMode = walMode;
         this.decodePlugin = decodePlugin;
@@ -116,6 +169,8 @@ public class GaussDBCDCTableSource implements ScanTableSource {
                         .password(password)
                         .slotName(slotName)
                         .snapshotMode(snapshotMode)
+                        .chunkSize(chunkSize)
+                        .connectTimeoutMs(connectTimeoutMs)
                         .pollIntervalMs(pollIntervalMs)
                         .walMode(walMode)
                         .decodePlugin(decodePlugin)
@@ -144,6 +199,8 @@ public class GaussDBCDCTableSource implements ScanTableSource {
                 password,
                 slotName,
                 snapshotMode,
+                chunkSize,
+                connectTimeoutMs,
                 pollIntervalMs,
                 walMode,
                 decodePlugin,

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSource.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSource.java
@@ -50,6 +50,8 @@ public class GaussDBCDCTableSource implements ScanTableSource {
     private final Integer replicationPort;
     /** Output format: "raw" (default, RowData) or "json" (single STRING column). */
     private final String outputFormat;
+    /** JSON sub-format: "debezium" (default), "canal", or "haier". */
+    private final String outputJsonFormat;
 
     private final DataType physicalRowDataType;
 
@@ -72,6 +74,7 @@ public class GaussDBCDCTableSource implements ScanTableSource {
             String sslMode,
             Integer replicationPort,
             String outputFormat,
+            String outputJsonFormat,
             DataType physicalRowDataType) {
         this.hostname = hostname;
         this.port = port;
@@ -91,6 +94,7 @@ public class GaussDBCDCTableSource implements ScanTableSource {
         this.sslMode = sslMode;
         this.replicationPort = replicationPort;
         this.outputFormat = outputFormat;
+        this.outputJsonFormat = outputJsonFormat;
         this.physicalRowDataType = physicalRowDataType;
     }
 
@@ -121,6 +125,7 @@ public class GaussDBCDCTableSource implements ScanTableSource {
                         .sslMode(sslMode)
                         .replicationPort(replicationPort)
                         .outputFormat(outputFormat)
+                        .outputJsonFormat(outputJsonFormat)
                         .build();
 
         // SourceFunctionProvider is available since Flink 1.11, compatible with 1.13~1.17
@@ -148,6 +153,7 @@ public class GaussDBCDCTableSource implements ScanTableSource {
                 sslMode,
                 replicationPort,
                 outputFormat,
+                outputJsonFormat,
                 physicalRowDataType);
     }
 

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactory.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactory.java
@@ -70,6 +70,7 @@ public class GaussDBCDCTableSourceFactory implements DynamicTableSourceFactory {
         options.add(GaussDBCDCOptions.DECODE_STYLE);
         options.add(GaussDBCDCOptions.SENDING_BATCH);
         options.add(GaussDBCDCOptions.SSL_MODE);
+        options.add(GaussDBCDCOptions.OUTPUT_FORMAT);
         return options;
     }
 
@@ -98,6 +99,7 @@ public class GaussDBCDCTableSourceFactory implements DynamicTableSourceFactory {
         String decodeStyle = config.get(GaussDBCDCOptions.DECODE_STYLE);
         boolean sendingBatch = config.get(GaussDBCDCOptions.SENDING_BATCH);
         String sslMode = config.get(GaussDBCDCOptions.SSL_MODE);
+        String outputFormat = config.get(GaussDBCDCOptions.OUTPUT_FORMAT);
 
         // Use getCatalogTable().getResolvedSchema().toPhysicalRowDataType() instead of
         // context.getPhysicalRowDataType() for Flink 1.13~1.14 compatibility.
@@ -123,6 +125,7 @@ public class GaussDBCDCTableSourceFactory implements DynamicTableSourceFactory {
                 sendingBatch,
                 sslMode,
                 replicationPort,
+                outputFormat,
                 physicalRowDataType);
     }
 }

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactory.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactory.java
@@ -71,6 +71,7 @@ public class GaussDBCDCTableSourceFactory implements DynamicTableSourceFactory {
         options.add(GaussDBCDCOptions.SENDING_BATCH);
         options.add(GaussDBCDCOptions.SSL_MODE);
         options.add(GaussDBCDCOptions.OUTPUT_FORMAT);
+        options.add(GaussDBCDCOptions.OUTPUT_JSON_FORMAT);
         return options;
     }
 
@@ -100,6 +101,7 @@ public class GaussDBCDCTableSourceFactory implements DynamicTableSourceFactory {
         boolean sendingBatch = config.get(GaussDBCDCOptions.SENDING_BATCH);
         String sslMode = config.get(GaussDBCDCOptions.SSL_MODE);
         String outputFormat = config.get(GaussDBCDCOptions.OUTPUT_FORMAT);
+        String outputJsonFormat = config.get(GaussDBCDCOptions.OUTPUT_JSON_FORMAT);
 
         // Use getCatalogTable().getResolvedSchema().toPhysicalRowDataType() instead of
         // context.getPhysicalRowDataType() for Flink 1.13~1.14 compatibility.
@@ -126,6 +128,7 @@ public class GaussDBCDCTableSourceFactory implements DynamicTableSourceFactory {
                 sslMode,
                 replicationPort,
                 outputFormat,
+                outputJsonFormat,
                 physicalRowDataType);
     }
 }

--- a/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactory.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/main/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactory.java
@@ -22,12 +22,14 @@ import org.apache.flink.annotation.Internal;
 import org.apache.flink.configuration.ConfigOption;
 import org.apache.flink.configuration.ReadableConfig;
 import org.apache.flink.connector.gaussdbcdc.GaussDBCDCOptions;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.connector.source.DynamicTableSource;
 import org.apache.flink.table.factories.DynamicTableSourceFactory;
 import org.apache.flink.table.factories.FactoryUtil;
 import org.apache.flink.table.types.DataType;
 
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 
 /** Factory for creating GaussDB CDC table source (Flink 1.13~1.17 compatible). */
@@ -93,15 +95,41 @@ public class GaussDBCDCTableSourceFactory implements DynamicTableSourceFactory {
         String password = config.get(GaussDBCDCOptions.PASSWORD);
         String slotName = config.get(GaussDBCDCOptions.SLOT_NAME);
         boolean snapshotMode = config.get(GaussDBCDCOptions.SNAPSHOT_MODE);
+        int chunkSize = config.get(GaussDBCDCOptions.CHUNK_SIZE);
+        int connectTimeoutMs = config.get(GaussDBCDCOptions.CONNECT_TIMEOUT_MS);
         int pollIntervalMs = config.get(GaussDBCDCOptions.POLL_INTERVAL_MS);
         boolean walMode = config.get(GaussDBCDCOptions.WAL_MODE);
-        String decodePlugin = config.get(GaussDBCDCOptions.DECODE_PLUGIN);
+        Map<String, String> rawOptions = context.getCatalogTable().getOptions();
+        boolean hasDecodePlugin = rawOptions.containsKey(GaussDBCDCOptions.DECODE_PLUGIN.key());
+        boolean hasLegacyPlugin = rawOptions.containsKey(GaussDBCDCOptions.PLUGIN_NAME.key());
+        if (hasDecodePlugin
+                && hasLegacyPlugin
+                && !rawOptions
+                        .get(GaussDBCDCOptions.DECODE_PLUGIN.key())
+                        .equalsIgnoreCase(rawOptions.get(GaussDBCDCOptions.PLUGIN_NAME.key()))) {
+            throw new ValidationException(
+                    "Conflicting decode.plugin and deprecated plugin.name values");
+        }
+        String decodePlugin =
+                hasDecodePlugin
+                        ? config.get(GaussDBCDCOptions.DECODE_PLUGIN)
+                        : hasLegacyPlugin
+                                ? config.get(GaussDBCDCOptions.PLUGIN_NAME)
+                                : config.get(GaussDBCDCOptions.DECODE_PLUGIN);
         int parallelDecodeNum = config.get(GaussDBCDCOptions.PARALLEL_DECODE_NUM);
         String decodeStyle = config.get(GaussDBCDCOptions.DECODE_STYLE);
         boolean sendingBatch = config.get(GaussDBCDCOptions.SENDING_BATCH);
         String sslMode = config.get(GaussDBCDCOptions.SSL_MODE);
         String outputFormat = config.get(GaussDBCDCOptions.OUTPUT_FORMAT);
         String outputJsonFormat = config.get(GaussDBCDCOptions.OUTPUT_JSON_FORMAT);
+        validateOptions(
+                chunkSize,
+                connectTimeoutMs,
+                pollIntervalMs,
+                parallelDecodeNum,
+                decodeStyle,
+                outputFormat,
+                outputJsonFormat);
 
         // Use getCatalogTable().getResolvedSchema().toPhysicalRowDataType() instead of
         // context.getPhysicalRowDataType() for Flink 1.13~1.14 compatibility.
@@ -119,6 +147,8 @@ public class GaussDBCDCTableSourceFactory implements DynamicTableSourceFactory {
                 password,
                 slotName,
                 snapshotMode,
+                chunkSize,
+                connectTimeoutMs,
                 pollIntervalMs,
                 walMode,
                 decodePlugin,
@@ -130,5 +160,37 @@ public class GaussDBCDCTableSourceFactory implements DynamicTableSourceFactory {
                 outputFormat,
                 outputJsonFormat,
                 physicalRowDataType);
+    }
+
+    private static void validateOptions(
+            int chunkSize,
+            int connectTimeoutMs,
+            int pollIntervalMs,
+            int parallelDecodeNum,
+            String decodeStyle,
+            String outputFormat,
+            String outputJsonFormat) {
+        if (chunkSize <= 0 || connectTimeoutMs <= 0 || pollIntervalMs <= 0) {
+            throw new ValidationException(
+                    "chunk.size, connect.timeout.ms, and poll.interval.ms must be greater than zero");
+        }
+        if (parallelDecodeNum < 1 || parallelDecodeNum > 20) {
+            throw new ValidationException("parallel-decode-num must be between 1 and 20");
+        }
+        if (!"b".equalsIgnoreCase(decodeStyle)
+                && !"j".equalsIgnoreCase(decodeStyle)
+                && !"t".equalsIgnoreCase(decodeStyle)) {
+            throw new ValidationException("decode-style must be one of b, j, or t");
+        }
+        if (!"raw".equalsIgnoreCase(outputFormat) && !"json".equalsIgnoreCase(outputFormat)) {
+            throw new ValidationException("output.format must be raw or json");
+        }
+        if ("json".equalsIgnoreCase(outputFormat)
+                && !"debezium".equalsIgnoreCase(outputJsonFormat)
+                && !"canal".equalsIgnoreCase(outputJsonFormat)
+                && !"he".equalsIgnoreCase(outputJsonFormat)) {
+            throw new ValidationException(
+                    "output.json.format must be debezium, canal, or he when output.format=json");
+        }
     }
 }

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/GaussDBCDCOptionsTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/GaussDBCDCOptionsTest.java
@@ -34,7 +34,7 @@ public class GaussDBCDCOptionsTest {
         assertEquals(Integer.valueOf(8000), GaussDBCDCOptions.PORT.defaultValue());
         assertEquals("public", GaussDBCDCOptions.SCHEMA.defaultValue());
         assertEquals("flink_cdc_slot", GaussDBCDCOptions.SLOT_NAME.defaultValue());
-        assertEquals("pgoutput", GaussDBCDCOptions.PLUGIN_NAME.defaultValue());
+        assertNull(GaussDBCDCOptions.PLUGIN_NAME.defaultValue());
         assertEquals(Boolean.TRUE, GaussDBCDCOptions.SNAPSHOT_MODE.defaultValue());
         assertEquals(Integer.valueOf(1000), GaussDBCDCOptions.CHUNK_SIZE.defaultValue());
         assertEquals(Integer.valueOf(30000), GaussDBCDCOptions.CONNECT_TIMEOUT_MS.defaultValue());

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/ChangeDataPollerTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/ChangeDataPollerTest.java
@@ -29,8 +29,10 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.util.Collections;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -163,8 +165,8 @@ class ChangeDataPollerTest {
         when(insertStmt.executeQuery()).thenReturn(insertRs);
         when(insertRs.getMetaData()).thenReturn(mockMeta);
         when(mockConnection.prepareStatement(
-                        "SELECT id, name, gender, age, class_name, score, created_date, updated_at "
-                                + "FROM public.test_table WHERE id > ? ORDER BY id LIMIT 1000"))
+                        "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                                + "FROM \"public\".\"test_table\" WHERE \"id\" > ? ORDER BY \"id\" LIMIT 1000"))
                 .thenReturn(insertStmt);
 
         poller.pollNewInserts();
@@ -185,8 +187,8 @@ class ChangeDataPollerTest {
         when(updateStmt.executeQuery()).thenReturn(updateRs);
         when(updateRs.getMetaData()).thenReturn(mockMeta);
         when(mockConnection.prepareStatement(
-                        "SELECT id, name, gender, age, class_name, score, created_date, updated_at "
-                                + "FROM public.test_table WHERE updated_at > ? ORDER BY updated_at LIMIT 1000"))
+                        "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                                + "FROM \"public\".\"test_table\" WHERE \"updated_at\" > ? ORDER BY \"updated_at\", \"id\" LIMIT 1000"))
                 .thenReturn(updateStmt);
 
         java.util.List<ChangeEvent<org.apache.flink.table.data.RowData>> events =
@@ -213,8 +215,8 @@ class ChangeDataPollerTest {
         when(updateStmt.executeQuery()).thenReturn(updateRs);
         when(updateRs.getMetaData()).thenReturn(mockMeta);
         when(mockConnection.prepareStatement(
-                        "SELECT id, name, gender, age, class_name, score, created_date, updated_at "
-                                + "FROM public.test_table WHERE updated_at > ? ORDER BY updated_at LIMIT 1000"))
+                        "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                                + "FROM \"public\".\"test_table\" WHERE \"updated_at\" > ? ORDER BY \"updated_at\", \"id\" LIMIT 1000"))
                 .thenReturn(updateStmt);
 
         java.util.List<ChangeEvent<org.apache.flink.table.data.RowData>> events =
@@ -240,8 +242,8 @@ class ChangeDataPollerTest {
         when(updateStmt.executeQuery()).thenReturn(updateRs);
         when(updateRs.getMetaData()).thenReturn(mockMeta);
         when(mockConnection.prepareStatement(
-                        "SELECT id, name, gender, age, class_name, score, created_date, updated_at "
-                                + "FROM public.test_table WHERE updated_at > ? ORDER BY updated_at LIMIT 1000"))
+                        "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                                + "FROM \"public\".\"test_table\" WHERE \"updated_at\" > ? ORDER BY \"updated_at\", \"id\" LIMIT 1000"))
                 .thenReturn(updateStmt);
 
         java.util.List<ChangeEvent<org.apache.flink.table.data.RowData>> events =
@@ -266,8 +268,8 @@ class ChangeDataPollerTest {
         when(insertStmt.executeQuery()).thenReturn(insertRs);
         when(insertRs.getMetaData()).thenReturn(mockMeta);
         when(mockConnection.prepareStatement(
-                        "SELECT id, name, gender, age, class_name, score, created_date, updated_at "
-                                + "FROM public.test_table WHERE id > ? ORDER BY id LIMIT 1000"))
+                        "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                                + "FROM \"public\".\"test_table\" WHERE \"id\" > ? ORDER BY \"id\" LIMIT 1000"))
                 .thenReturn(insertStmt);
 
         poller.pollNewInserts();
@@ -278,7 +280,7 @@ class ChangeDataPollerTest {
         when(deleteRs.next()).thenReturn(false); // No rows in DB
         when(deleteStmt.executeQuery()).thenReturn(deleteRs);
         when(deleteRs.getMetaData()).thenReturn(mockMeta);
-        when(mockConnection.prepareStatement("SELECT id FROM public.test_table"))
+        when(mockConnection.prepareStatement("SELECT \"id\" FROM \"public\".\"test_table\""))
                 .thenReturn(deleteStmt);
 
         java.util.List<ChangeEvent<org.apache.flink.table.data.RowData>> events =
@@ -304,8 +306,8 @@ class ChangeDataPollerTest {
         when(insertStmt.executeQuery()).thenReturn(insertRs);
         when(insertRs.getMetaData()).thenReturn(mockMeta);
         when(mockConnection.prepareStatement(
-                        "SELECT id, name, gender, age, class_name, score, created_date, updated_at "
-                                + "FROM public.test_table WHERE id > ? ORDER BY id LIMIT 1000"))
+                        "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                                + "FROM \"public\".\"test_table\" WHERE \"id\" > ? ORDER BY \"id\" LIMIT 1000"))
                 .thenReturn(insertStmt);
 
         poller.pollNewInserts();
@@ -317,7 +319,7 @@ class ChangeDataPollerTest {
         when(deleteRs.getLong("id")).thenReturn(1L);
         when(deleteStmt.executeQuery()).thenReturn(deleteRs);
         when(deleteRs.getMetaData()).thenReturn(mockMeta);
-        when(mockConnection.prepareStatement("SELECT id FROM public.test_table"))
+        when(mockConnection.prepareStatement("SELECT \"id\" FROM \"public\".\"test_table\""))
                 .thenReturn(deleteStmt);
 
         java.util.List<ChangeEvent<org.apache.flink.table.data.RowData>> events =
@@ -334,8 +336,8 @@ class ChangeDataPollerTest {
         when(insertStmt.executeQuery()).thenReturn(insertRs);
         when(insertRs.getMetaData()).thenReturn(mockMeta);
         when(mockConnection.prepareStatement(
-                        "SELECT id, name, gender, age, class_name, score, created_date, updated_at "
-                                + "FROM public.test_table WHERE id > ? ORDER BY id LIMIT 1000"))
+                        "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                                + "FROM \"public\".\"test_table\" WHERE \"id\" > ? ORDER BY \"id\" LIMIT 1000"))
                 .thenReturn(insertStmt);
 
         // Setup updates
@@ -345,8 +347,8 @@ class ChangeDataPollerTest {
         when(updateStmt.executeQuery()).thenReturn(updateRs);
         when(updateRs.getMetaData()).thenReturn(mockMeta);
         when(mockConnection.prepareStatement(
-                        "SELECT id, name, gender, age, class_name, score, created_date, updated_at "
-                                + "FROM public.test_table WHERE updated_at > ? ORDER BY updated_at LIMIT 1000"))
+                        "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                                + "FROM \"public\".\"test_table\" WHERE \"updated_at\" > ? ORDER BY \"updated_at\", \"id\" LIMIT 1000"))
                 .thenReturn(updateStmt);
 
         // Setup deletes
@@ -355,7 +357,7 @@ class ChangeDataPollerTest {
         when(deleteRs.next()).thenReturn(false);
         when(deleteStmt.executeQuery()).thenReturn(deleteRs);
         when(deleteRs.getMetaData()).thenReturn(mockMeta);
-        when(mockConnection.prepareStatement("SELECT id FROM public.test_table"))
+        when(mockConnection.prepareStatement("SELECT \"id\" FROM \"public\".\"test_table\""))
                 .thenReturn(deleteStmt);
 
         java.util.List<ChangeEvent<org.apache.flink.table.data.RowData>> events =
@@ -372,16 +374,16 @@ class ChangeDataPollerTest {
         when(insertStmt.executeQuery()).thenReturn(insertRs);
         when(insertRs.getMetaData()).thenReturn(mockMeta);
         when(mockConnection.prepareStatement(
-                        "SELECT id, name, gender, age, class_name, score, created_date, updated_at "
-                                + "FROM public.test_table WHERE id > ? ORDER BY id LIMIT 1000"))
+                        "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                                + "FROM \"public\".\"test_table\" WHERE \"id\" > ? ORDER BY \"id\" LIMIT 1000"))
                 .thenReturn(insertStmt);
 
         // Setup updates - throws SQLException
         PreparedStatement updateStmt = mock(PreparedStatement.class);
         when(updateStmt.executeQuery()).thenThrow(new SQLException("column updated_at not found"));
         when(mockConnection.prepareStatement(
-                        "SELECT id, name, gender, age, class_name, score, created_date, updated_at "
-                                + "FROM public.test_table WHERE updated_at > ? ORDER BY updated_at LIMIT 1000"))
+                        "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                                + "FROM \"public\".\"test_table\" WHERE \"updated_at\" > ? ORDER BY \"updated_at\", \"id\" LIMIT 1000"))
                 .thenReturn(updateStmt);
 
         // Setup deletes
@@ -390,13 +392,14 @@ class ChangeDataPollerTest {
         when(deleteRs.next()).thenReturn(false);
         when(deleteStmt.executeQuery()).thenReturn(deleteRs);
         when(deleteRs.getMetaData()).thenReturn(mockMeta);
-        when(mockConnection.prepareStatement("SELECT id FROM public.test_table"))
+        when(mockConnection.prepareStatement("SELECT \"id\" FROM \"public\".\"test_table\""))
                 .thenReturn(deleteStmt);
 
-        // Should not throw - update failure is caught
-        java.util.List<ChangeEvent<org.apache.flink.table.data.RowData>> events =
-                poller.pollAllChanges();
-        assertThat(events).isEmpty(); // inserts empty, updates failed, deletes empty
+        // Poll failures must fail the source so Flink can restart from checkpoint; silently
+        // continuing would permanently skip update events.
+        assertThatThrownBy(poller::pollAllChanges)
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("updated_at");
     }
 
     @Test
@@ -417,8 +420,8 @@ class ChangeDataPollerTest {
         when(snapshotStmt.executeQuery()).thenReturn(snapshotRs);
         when(snapshotRs.getMetaData()).thenReturn(mockMeta);
         when(mockConnection.prepareStatement(
-                        "SELECT id, name, gender, age, class_name, score, created_date, updated_at "
-                                + "FROM public.test_table"))
+                        "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                                + "FROM \"public\".\"test_table\" ORDER BY \"id\""))
                 .thenReturn(snapshotStmt);
 
         poller.loadSnapshot();
@@ -433,8 +436,8 @@ class ChangeDataPollerTest {
         when(snapshotStmt.executeQuery()).thenReturn(snapshotRs);
         when(snapshotRs.getMetaData()).thenReturn(mockMeta);
         when(mockConnection.prepareStatement(
-                        "SELECT id, name, gender, age, class_name, score, created_date, updated_at "
-                                + "FROM public.test_table"))
+                        "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                                + "FROM \"public\".\"test_table\" ORDER BY \"id\""))
                 .thenReturn(snapshotStmt);
 
         poller.setLastPolledId(10L);
@@ -462,5 +465,155 @@ class ChangeDataPollerTest {
         java.util.List<ChangeEvent<org.apache.flink.table.data.RowData>> events =
                 poller.pollNewInserts();
         assertThat(events).hasSize(1);
+    }
+
+    @Test
+    void testUpdatePaginationContinuesWithinSameTimestamp() throws SQLException {
+        String firstPageSql =
+                "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                        + "FROM \"public\".\"test_table\" WHERE \"updated_at\" > ? "
+                        + "ORDER BY \"updated_at\", \"id\" LIMIT 1000";
+        String nextPageSql =
+                "SELECT \"id\", \"name\", \"gender\", \"age\", \"class_name\", \"score\", \"created_date\", \"updated_at\" "
+                        + "FROM \"public\".\"test_table\" WHERE \"updated_at\" > ? "
+                        + "OR (\"updated_at\" = ? AND \"id\" > ?) "
+                        + "ORDER BY \"updated_at\", \"id\" LIMIT 1000";
+
+        PreparedStatement firstStmt = mock(PreparedStatement.class);
+        ResultSet firstRs = mock(ResultSet.class);
+        when(firstStmt.executeQuery()).thenReturn(firstRs);
+        when(firstRs.getMetaData()).thenReturn(mockMeta);
+        when(firstRs.next()).thenReturn(true, false);
+        when(firstRs.getObject("id")).thenReturn(1000L);
+        when(firstRs.getTimestamp("updated_at")).thenReturn(new Timestamp(5000L));
+
+        PreparedStatement nextStmt = mock(PreparedStatement.class);
+        ResultSet nextRs = mock(ResultSet.class);
+        when(nextStmt.executeQuery()).thenReturn(nextRs);
+        when(nextRs.getMetaData()).thenReturn(mockMeta);
+        when(nextRs.next()).thenReturn(true, false);
+        when(nextRs.getObject("id")).thenReturn(1001L);
+        when(nextRs.getTimestamp("updated_at")).thenReturn(new Timestamp(5000L));
+
+        when(mockConnection.prepareStatement(firstPageSql)).thenReturn(firstStmt);
+        when(mockConnection.prepareStatement(nextPageSql)).thenReturn(nextStmt);
+
+        assertThat(poller.pollUpdates()).hasSize(1);
+        assertThat(poller.pollUpdates()).hasSize(1);
+        org.mockito.Mockito.verify(nextStmt).setTimestamp(1, new Timestamp(5000L));
+        org.mockito.Mockito.verify(nextStmt).setTimestamp(2, new Timestamp(5000L));
+        org.mockito.Mockito.verify(nextStmt).setObject(3, 1000L);
+    }
+
+    @Test
+    void testPollingSupportsStringPrimaryKey() throws SQLException {
+        Connection connection = mock(Connection.class);
+        DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+        ResultSet columns = mock(ResultSet.class);
+        ResultSet primaryKeys = mock(ResultSet.class);
+        when(connection.getMetaData()).thenReturn(metadata);
+        when(metadata.getIdentifierQuoteString()).thenReturn("\"");
+        when(metadata.getColumns(null, "public", "string_pk", null)).thenReturn(columns);
+        when(columns.next()).thenReturn(true, false);
+        when(columns.getString("COLUMN_NAME")).thenReturn("code");
+        when(metadata.getPrimaryKeys(null, "public", "string_pk")).thenReturn(primaryKeys);
+        when(primaryKeys.next()).thenReturn(true, false);
+        when(primaryKeys.getString("COLUMN_NAME")).thenReturn("code");
+
+        ResultSetMetaData rowMeta = mock(ResultSetMetaData.class);
+        when(rowMeta.getColumnCount()).thenReturn(1);
+        when(rowMeta.getColumnType(1)).thenReturn(java.sql.Types.VARCHAR);
+        PreparedStatement firstStmt = mock(PreparedStatement.class);
+        ResultSet firstRs = mock(ResultSet.class);
+        when(firstStmt.executeQuery()).thenReturn(firstRs);
+        when(firstRs.getMetaData()).thenReturn(rowMeta);
+        when(firstRs.next()).thenReturn(true, false);
+        when(firstRs.getObject("code")).thenReturn("A");
+        when(firstRs.getString(1)).thenReturn("A");
+        PreparedStatement nextStmt = mock(PreparedStatement.class);
+        ResultSet nextRs = mock(ResultSet.class);
+        when(nextStmt.executeQuery()).thenReturn(nextRs);
+        when(nextRs.getMetaData()).thenReturn(rowMeta);
+        when(nextRs.next()).thenReturn(true, false);
+        when(nextRs.getObject("code")).thenReturn("B");
+        when(nextRs.getString(1)).thenReturn("B");
+        when(connection.prepareStatement(
+                        "SELECT \"code\" FROM \"public\".\"string_pk\" ORDER BY \"code\" LIMIT 1000"))
+                .thenReturn(firstStmt);
+        when(connection.prepareStatement(
+                        "SELECT \"code\" FROM \"public\".\"string_pk\" WHERE \"code\" > ? ORDER BY \"code\" LIMIT 1000"))
+                .thenReturn(nextStmt);
+
+        ChangeDataPoller stringPoller =
+                new ChangeDataPoller(
+                        connection,
+                        "db",
+                        "public",
+                        Collections.singletonList("string_pk"),
+                        "raw",
+                        "debezium");
+        assertThat(stringPoller.pollNewInserts()).hasSize(1);
+        assertThat(stringPoller.pollNewInserts()).hasSize(1);
+        org.mockito.Mockito.verify(nextStmt).setObject(1, "A");
+    }
+
+    @Test
+    void testPollingRejectsCompositePrimaryKey() throws SQLException {
+        Connection connection = mock(Connection.class);
+        DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+        ResultSet columns = mock(ResultSet.class);
+        ResultSet primaryKeys = mock(ResultSet.class);
+        when(connection.getMetaData()).thenReturn(metadata);
+        when(metadata.getIdentifierQuoteString()).thenReturn("\"");
+        when(metadata.getColumns(null, "public", "composite_pk", null)).thenReturn(columns);
+        when(columns.next()).thenReturn(true, true, false);
+        when(columns.getString("COLUMN_NAME")).thenReturn("tenant_id", "record_id");
+        when(metadata.getPrimaryKeys(null, "public", "composite_pk")).thenReturn(primaryKeys);
+        when(primaryKeys.next()).thenReturn(true, true, false);
+        when(primaryKeys.getString("COLUMN_NAME")).thenReturn("tenant_id", "record_id");
+
+        ChangeDataPoller compositePoller =
+                new ChangeDataPoller(
+                        connection,
+                        "db",
+                        "public",
+                        Collections.singletonList("composite_pk"),
+                        "raw",
+                        "debezium");
+
+        assertThatThrownBy(compositePoller::pollNewInserts)
+                .isInstanceOf(SQLException.class)
+                .hasMessageContaining("composite key");
+    }
+
+    @Test
+    void testPollingStateRestoresDeleteSnapshot() throws Exception {
+        PreparedStatement insertStmt = mock(PreparedStatement.class);
+        ResultSet insertRs = mock(ResultSet.class);
+        when(insertStmt.executeQuery()).thenReturn(insertRs);
+        when(insertRs.getMetaData()).thenReturn(mockMeta);
+        when(insertRs.next()).thenReturn(true, false);
+        when(insertRs.getObject("id")).thenReturn(7L);
+        when(mockConnection.prepareStatement(anyString())).thenReturn(insertStmt);
+        assertThat(poller.pollNewInserts()).hasSize(1);
+
+        byte[] state = poller.serializeState();
+
+        Connection restoredConnection = mock(Connection.class);
+        DatabaseMetaData restoredMetadata = mock(DatabaseMetaData.class);
+        when(restoredConnection.getMetaData()).thenReturn(restoredMetadata);
+        when(restoredMetadata.getIdentifierQuoteString()).thenReturn("\"");
+        PreparedStatement deleteStmt = mock(PreparedStatement.class);
+        ResultSet deleteRs = mock(ResultSet.class);
+        when(deleteStmt.executeQuery()).thenReturn(deleteRs);
+        when(deleteRs.next()).thenReturn(false);
+        when(restoredConnection.prepareStatement("SELECT \"id\" FROM \"public\".\"test_table\""))
+                .thenReturn(deleteStmt);
+
+        ChangeDataPoller restored =
+                new ChangeDataPoller(restoredConnection, "public", "test_table", "id");
+        restored.restoreState(state);
+        assertThat(restored.getLastPolledId()).isEqualTo(7L);
+        assertThat(restored.pollDeletes()).hasSize(1);
     }
 }

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCBinaryDecodePerfITCase.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCBinaryDecodePerfITCase.java
@@ -33,6 +33,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.List;
+import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -48,13 +49,18 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 class GaussDBCDCBinaryDecodePerfITCase {
 
-    private static final String HOST = "1.92.120.69";
-    private static final int PORT = 8000;
-    private static final String DATABASE = "test";
-    private static final String USERNAME = "root";
-    private static final String PASSWORD = "GuassDB123";
-    private static final String SCHEMA = "public";
-    private static final String PERF_TABLE = "perf_test_binary_decode";
+    private static final Properties SYSTEM_PROPERTIES = System.getProperties();
+    private static final String HOST = SYSTEM_PROPERTIES.getProperty("gaussdb.host", "localhost");
+    private static final int PORT =
+            Integer.parseInt(SYSTEM_PROPERTIES.getProperty("gaussdb.port", "8000"));
+    private static final String DATABASE =
+            SYSTEM_PROPERTIES.getProperty("gaussdb.database", "test");
+    private static final String USERNAME =
+            SYSTEM_PROPERTIES.getProperty("gaussdb.username", "root");
+    private static final String PASSWORD = SYSTEM_PROPERTIES.getProperty("gaussdb.password", "");
+    private static final String SCHEMA = SYSTEM_PROPERTIES.getProperty("gaussdb.schema", "public");
+    private static final String PERF_TABLE =
+            SYSTEM_PROPERTIES.getProperty("gaussdb.perf.table", "perf_test_binary_decode");
 
     /** Number of rows to insert for each test run. */
     private static final int BATCH_SIZE = 10000;
@@ -63,7 +69,9 @@ class GaussDBCDCBinaryDecodePerfITCase {
 
     @BeforeAll
     void setUp() throws Exception {
-        assumeThat(Boolean.getBoolean("gaussdb.test.enabled"))
+        assumeThat(
+                        Boolean.parseBoolean(
+                                SYSTEM_PROPERTIES.getProperty("gaussdb.test.enabled", "false")))
                 .as("GaussDB perf test disabled - set -Dgaussdb.test.enabled=true")
                 .isTrue();
 

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunctionITCase.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunctionITCase.java
@@ -28,14 +28,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestInstance;
 import org.junit.jupiter.api.TestMethodOrder;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Properties;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assumptions.assumeThat;
@@ -63,19 +70,75 @@ import static org.assertj.core.api.Assumptions.assumeThat;
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
 class GaussDBCDCSourceFunctionITCase {
 
-    private static final String HOST = "1.92.120.69";
-    private static final int PORT = 8000;
-    private static final String DATABASE = "test";
-    private static final String USERNAME = "root";
-    private static final String PASSWORD = "GuassDB123";
-    private static final String SCHEMA = "public";
-    private static final String TEST_TABLE = "flink_cdc_sf_it_test";
+    private static final Properties SYSTEM_PROPERTIES = System.getProperties();
+    private static final String HOST = SYSTEM_PROPERTIES.getProperty("gaussdb.host", "localhost");
+    private static final int PORT =
+            Integer.parseInt(SYSTEM_PROPERTIES.getProperty("gaussdb.port", "8000"));
+    private static final String DATABASE =
+            SYSTEM_PROPERTIES.getProperty("gaussdb.database", "test");
+    private static final String USERNAME =
+            SYSTEM_PROPERTIES.getProperty("gaussdb.username", "root");
+    private static final String PASSWORD = SYSTEM_PROPERTIES.getProperty("gaussdb.password", "");
+    private static final String SCHEMA = SYSTEM_PROPERTIES.getProperty("gaussdb.schema", "public");
+    private static final String TEST_TABLE =
+            SYSTEM_PROPERTIES.getProperty("gaussdb.table", "flink_cdc_sf_it_test");
 
     private Connection connection;
 
+    @Test
+    void testPollingUsesPrimaryKeyTieBreakerForSameTimestamp() throws Exception {
+        String table = "flink_cdc_sf_it_polling_cursor";
+        String qualified = SCHEMA + "." + table;
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("DROP TABLE IF EXISTS " + qualified);
+            stmt.execute(
+                    "CREATE TABLE "
+                            + qualified
+                            + " (code VARCHAR(32) PRIMARY KEY, value_col VARCHAR(64), updated_at TIMESTAMP)");
+            stmt.execute(
+                    "INSERT INTO "
+                            + qualified
+                            + " VALUES ('A', 'before-a', '2026-01-01 00:00:00'),"
+                            + " ('B', 'before-b', '2026-01-01 00:00:00'),"
+                            + " ('C', 'before-c', '2026-01-01 00:00:00')");
+        }
+
+        try {
+            ChangeDataPoller poller =
+                    new ChangeDataPoller(
+                            connection,
+                            DATABASE,
+                            SCHEMA,
+                            Collections.singletonList(table),
+                            "raw",
+                            "debezium",
+                            2);
+            poller.loadSnapshot();
+
+            try (PreparedStatement update =
+                    connection.prepareStatement(
+                            "UPDATE " + qualified + " SET value_col = 'after', updated_at = ?")) {
+                update.setTimestamp(1, Timestamp.valueOf("2026-01-02 00:00:00"));
+                assertThat(update.executeUpdate()).isEqualTo(3);
+            }
+
+            assertThat(poller.pollUpdates()).hasSize(2);
+            assertThat(poller.pollUpdates()).hasSize(1);
+            assertThat(poller.pollUpdates()).isEmpty();
+            System.out.println(
+                    "[OK] Polling cursor emitted all same-timestamp rows across batch boundary");
+        } finally {
+            try (Statement stmt = connection.createStatement()) {
+                stmt.execute("DROP TABLE IF EXISTS " + qualified);
+            }
+        }
+    }
+
     @BeforeAll
     void setUp() throws Exception {
-        assumeThat(Boolean.getBoolean("gaussdb.test.enabled"))
+        assumeThat(
+                        Boolean.parseBoolean(
+                                SYSTEM_PROPERTIES.getProperty("gaussdb.test.enabled", "false")))
                 .as("GaussDB integration test disabled - set -Dgaussdb.test.enabled=true")
                 .isTrue();
 
@@ -119,7 +182,7 @@ class GaussDBCDCSourceFunctionITCase {
             stmt.execute(String.format("DROP TABLE IF EXISTS %s.%s", SCHEMA, TEST_TABLE));
             stmt.execute(
                     String.format(
-                            "CREATE TABLE %s.%s (id SERIAL PRIMARY KEY, name VARCHAR(100), age INT)",
+                            "CREATE TABLE %s.%s (id BIGINT PRIMARY KEY, name VARCHAR(100), age INT)",
                             SCHEMA, TEST_TABLE));
         }
     }
@@ -236,7 +299,7 @@ class GaussDBCDCSourceFunctionITCase {
         try (Statement stmt = connection.createStatement()) {
             stmt.execute(
                     String.format(
-                            "INSERT INTO %s.%s (name, age) VALUES ('Charlie', 35)",
+                            "INSERT INTO %s.%s (id, name, age) VALUES (1, 'Charlie', 35)",
                             SCHEMA, TEST_TABLE));
         }
 
@@ -317,7 +380,7 @@ class GaussDBCDCSourceFunctionITCase {
         try (Statement stmt = connection.createStatement()) {
             stmt.execute(
                     String.format(
-                            "INSERT INTO %s.%s (name, age) VALUES ('Diana', 28)",
+                            "INSERT INTO %s.%s (id, name, age) VALUES (2, 'Diana', 28)",
                             SCHEMA, TEST_TABLE));
             stmt.execute(
                     String.format(
@@ -386,7 +449,7 @@ class GaussDBCDCSourceFunctionITCase {
         try (Statement stmt = connection.createStatement()) {
             stmt.execute(
                     String.format(
-                            "INSERT INTO %s.%s (name, age) VALUES ('Eve', 22)",
+                            "INSERT INTO %s.%s (id, name, age) VALUES (3, 'Eve', 22)",
                             SCHEMA, TEST_TABLE));
         }
 
@@ -475,7 +538,7 @@ class GaussDBCDCSourceFunctionITCase {
         try (Statement stmt = connection.createStatement()) {
             stmt.execute(
                     String.format(
-                            "INSERT INTO %s.%s (name, age) VALUES ('Frank', 40)",
+                            "INSERT INTO %s.%s (id, name, age) VALUES (4, 'Frank', 40)",
                             SCHEMA, TEST_TABLE));
         }
 
@@ -518,7 +581,7 @@ class GaussDBCDCSourceFunctionITCase {
         try (Statement stmt = connection.createStatement()) {
             stmt.execute(
                     String.format(
-                            "INSERT INTO %s.%s (name, age) VALUES ('Grace', 33)",
+                            "INSERT INTO %s.%s (id, name, age) VALUES (5, 'Grace', 33)",
                             SCHEMA, TEST_TABLE));
         }
 
@@ -633,7 +696,7 @@ class GaussDBCDCSourceFunctionITCase {
         try (Statement stmt = connection.createStatement()) {
             stmt.execute(
                     String.format(
-                            "INSERT INTO %s.%s (name, age) VALUES ('Heidi', 27)",
+                            "INSERT INTO %s.%s (id, name, age) VALUES (6, 'Heidi', 27)",
                             SCHEMA, TEST_TABLE));
         }
 
@@ -661,7 +724,7 @@ class GaussDBCDCSourceFunctionITCase {
         try (Statement stmt = connection.createStatement()) {
             stmt.execute(
                     String.format(
-                            "INSERT INTO %s.%s (name, age) VALUES ('Ivan', 32)",
+                            "INSERT INTO %s.%s (id, name, age) VALUES (7, 'Ivan', 32)",
                             SCHEMA, TEST_TABLE));
         }
 
@@ -687,7 +750,337 @@ class GaussDBCDCSourceFunctionITCase {
         System.out.println("[OK] MppdbBinaryDecoder integration verified");
     }
 
+    // ---- Test 11: Snapshot/WAL handoff ----
+
+    @Test
+    @org.junit.jupiter.api.Order(11)
+    void testSlotPreparedBeforeSnapshotRetainsChange() throws Exception {
+        String slotName = "sf_it_handoff";
+        dropSlotIfExists(slotName);
+
+        String jdbcUrl = String.format("jdbc:gaussdb://%s:%d/%s", HOST, PORT, DATABASE);
+        WalReplicationStream stream =
+                new WalReplicationStream(
+                        connection,
+                        jdbcUrl,
+                        USERNAME,
+                        PASSWORD,
+                        slotName,
+                        "mppdb_decoding",
+                        4,
+                        "b",
+                        true,
+                        1000);
+
+        String snapshotStartLsn = stream.prepareSlotForSnapshot();
+        assertThat(snapshotStartLsn).isNotBlank();
+
+        // This commit represents a change made while the JDBC snapshot is still running.
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(
+                    String.format(
+                            "INSERT INTO %s.%s (id, name, age) VALUES (8, 'Handoff', 44)",
+                            SCHEMA, TEST_TABLE));
+        }
+
+        stream.initialize(snapshotStartLsn);
+        List<WalChange> changes = readChangesWithRetry(stream, 100, 10);
+        assertThat(changes)
+                .anySatisfy(
+                        change -> {
+                            assertThat(change.getType()).isEqualTo(WalChange.ChangeType.INSERT);
+                            assertThat(change.getSchema()).isEqualTo(SCHEMA);
+                            assertThat(change.getTable()).isEqualTo(TEST_TABLE);
+                        });
+
+        stream.close();
+        dropSlotIfExists(slotName);
+        System.out.println("[OK] Pre-snapshot slot retained handoff change");
+    }
+
+    @Test
+    @org.junit.jupiter.api.Order(12)
+    void testReplicaIdentityFullDeleteCommitAcrossReadBatches() throws Exception {
+        String slotName = "sf_it_full_delete";
+        dropSlotIfExists(slotName);
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute(
+                    String.format("ALTER TABLE %s.%s REPLICA IDENTITY FULL", SCHEMA, TEST_TABLE));
+            stmt.execute(
+                    String.format(
+                            "INSERT INTO %s.%s (id, name, age) VALUES (120012, 'full-delete', 42)",
+                            SCHEMA, TEST_TABLE));
+        }
+
+        String jdbcUrl = String.format("jdbc:gaussdb://%s:%d/%s", HOST, PORT, DATABASE);
+        WalReplicationStream stream =
+                new WalReplicationStream(
+                        connection,
+                        jdbcUrl,
+                        USERNAME,
+                        PASSWORD,
+                        slotName,
+                        "mppdb_decoding",
+                        4,
+                        "b",
+                        true,
+                        1000);
+
+        try {
+            stream.initialize();
+            assumeThat(stream.isUseReplicationApi())
+                    .as("This regression targets the SQL-function fallback")
+                    .isFalse();
+
+            try (Statement stmt = connection.createStatement()) {
+                stmt.execute(
+                        String.format("DELETE FROM %s.%s WHERE id = 120012", SCHEMA, TEST_TABLE));
+                stmt.execute(
+                        String.format(
+                                "INSERT INTO %s.%s (id, name, age) VALUES (120013, 'after-delete', 43)",
+                                SCHEMA, TEST_TABLE));
+            }
+
+            List<WalChange> allChanges = new ArrayList<>();
+            for (int i = 0; i < 30; i++) {
+                List<WalChange> batch = stream.readChanges(2);
+                if (!batch.isEmpty()) {
+                    allChanges.addAll(batch);
+                }
+                boolean hasDelete =
+                        allChanges.stream()
+                                .anyMatch(c -> c.getType() == WalChange.ChangeType.DELETE);
+                boolean hasInsert =
+                        allChanges.stream()
+                                .anyMatch(
+                                        c ->
+                                                c.getType() == WalChange.ChangeType.INSERT
+                                                        && TEST_TABLE.equals(c.getTable()));
+                if (hasDelete && hasInsert) {
+                    break;
+                }
+                Thread.sleep(200);
+            }
+
+            WalChange delete =
+                    allChanges.stream()
+                            .filter(c -> c.getType() == WalChange.ChangeType.DELETE)
+                            .findFirst()
+                            .orElseThrow(() -> new AssertionError("DELETE was not decoded"));
+            int beginIndex = -1;
+            int deleteIndex = -1;
+            int commitIndex = -1;
+            WalChange deleteCommit = null;
+            for (int i = 0; i < allChanges.size(); i++) {
+                WalChange change = allChanges.get(i);
+                if (change.getXid() != delete.getXid()) {
+                    continue;
+                }
+                if (change.getType() == WalChange.ChangeType.BEGIN) {
+                    beginIndex = i;
+                } else if (change == delete) {
+                    deleteIndex = i;
+                } else if (change.getType() == WalChange.ChangeType.COMMIT) {
+                    commitIndex = i;
+                    deleteCommit = change;
+                    break;
+                }
+            }
+            assertThat(beginIndex).isGreaterThanOrEqualTo(0);
+            assertThat(deleteIndex).isGreaterThan(beginIndex);
+            assertThat(commitIndex).isGreaterThan(deleteIndex);
+
+            GaussDBCDCSourceFunction source =
+                    GaussDBCDCSourceFunction.builder()
+                            .hostname(HOST)
+                            .port(PORT)
+                            .database(DATABASE)
+                            .schema(SCHEMA)
+                            .tableName(TEST_TABLE)
+                            .username(USERNAME)
+                            .password(PASSWORD)
+                            .walMode(true)
+                            .build();
+            setSourceField(source, "walReplicationStream", stream);
+            setSourceField(source, "snapshotCsn", -1L);
+
+            List<WalChange> beforeCommit =
+                    prepareSourceChanges(
+                            source,
+                            new ArrayList<>(allChanges.subList(beginIndex, deleteIndex + 1)));
+            assertThat(beforeCommit).isEmpty();
+            List<WalChange> afterCommit =
+                    prepareSourceChanges(
+                            source,
+                            new ArrayList<>(allChanges.subList(deleteIndex + 1, commitIndex + 1)));
+            assertThat(afterCommit).containsExactly(delete);
+            System.out.printf(
+                    "[OK] REPLICA IDENTITY FULL DELETE xid=%d survived source batch split; commitLsn=%s, commitCsn=%d%n",
+                    delete.getXid(), deleteCommit.getLsn(), deleteCommit.getCsn());
+        } finally {
+            stream.close();
+            dropSlotIfExists(slotName);
+        }
+    }
+
+    @Test
+    @org.junit.jupiter.api.Order(13)
+    void testSnapshotBoundaryFunctionCompatibility() throws Exception {
+        GaussDBCDCSourceFunction source =
+                GaussDBCDCSourceFunction.builder()
+                        .hostname(HOST)
+                        .port(PORT)
+                        .database(DATABASE)
+                        .schema(SCHEMA)
+                        .tableName(TEST_TABLE)
+                        .username(USERNAME)
+                        .password(PASSWORD)
+                        .walMode(true)
+                        .build();
+        setSourceField(source, "connection", connection);
+
+        try {
+            Method method =
+                    GaussDBCDCSourceFunction.class.getDeclaredMethod("exportSnapshotBoundary");
+            method.setAccessible(true);
+            Object boundary = method.invoke(source);
+
+            assertThat(readObjectField(boundary, "snapshotId").toString()).isNotBlank();
+            assertThat((Long) readObjectField(boundary, "csn")).isGreaterThanOrEqualTo(-1L);
+            System.out.printf(
+                    "[OK] Snapshot boundary compatibility: snapshot=%s, csn=%s%n",
+                    readObjectField(boundary, "snapshotId"), readObjectField(boundary, "csn"));
+        } finally {
+            connection.rollback();
+            connection.setAutoCommit(true);
+        }
+    }
+
+    @Test
+    @org.junit.jupiter.api.Order(14)
+    void testQuotedIdentifiersAndReconnectDdlDetection() throws Exception {
+        String quotedTable = TEST_TABLE + " Order";
+        String quotedPk = "select";
+        String quotedColumn = "customer\"name";
+        String quoteString = SqlIdentifierUtils.resolveQuoteString(connection);
+        String qualifiedTable = SqlIdentifierUtils.qualified(SCHEMA, quotedTable, quoteString);
+
+        try (Statement stmt = connection.createStatement()) {
+            stmt.execute("DROP TABLE IF EXISTS " + qualifiedTable);
+            stmt.execute(
+                    "CREATE TABLE "
+                            + qualifiedTable
+                            + " ("
+                            + SqlIdentifierUtils.quote(quotedPk, quoteString)
+                            + " BIGINT PRIMARY KEY, "
+                            + SqlIdentifierUtils.quote(quotedColumn, quoteString)
+                            + " VARCHAR(100))");
+            stmt.execute(
+                    "INSERT INTO "
+                            + qualifiedTable
+                            + " ("
+                            + SqlIdentifierUtils.quote(quotedPk, quoteString)
+                            + ", "
+                            + SqlIdentifierUtils.quote(quotedColumn, quoteString)
+                            + ") VALUES (7, 'quoted-ok')");
+        }
+
+        try {
+            ChangeDataPoller poller =
+                    new ChangeDataPoller(connection, SCHEMA, quotedTable, quotedPk);
+            assertThat(poller.pollNewInserts()).hasSize(1);
+
+            GaussDBCDCSourceFunction source =
+                    GaussDBCDCSourceFunction.builder()
+                            .hostname(HOST)
+                            .port(PORT)
+                            .database(DATABASE)
+                            .schema(SCHEMA)
+                            .tableName(quotedTable)
+                            .username(USERNAME)
+                            .password(PASSWORD)
+                            .walMode(true)
+                            .build();
+            setSourceField(source, "connection", connection);
+            setSourceField(source, "cachedColumnsByTable", new HashMap<String, List<String>>());
+            setSourceField(source, "cachedPkByTable", new HashMap<String, String>());
+
+            invokeSourceMethod(
+                    source, "cacheTableColumns", new Class<?>[] {String.class}, quotedTable);
+            invokeSourceMethod(
+                    source, "getPrimaryKeyColumn", new Class<?>[] {String.class}, quotedTable);
+            long[] range =
+                    (long[])
+                            invokeSourceMethod(
+                                    source,
+                                    "getIdRange",
+                                    new Class<?>[] {String.class, String.class},
+                                    quotedTable,
+                                    quotedPk);
+            assertThat(range).containsExactly(7L, 7L);
+
+            try (Statement stmt = connection.createStatement()) {
+                stmt.execute(
+                        "ALTER TABLE "
+                                + qualifiedTable
+                                + " ADD COLUMN "
+                                + SqlIdentifierUtils.quote("new column", quoteString)
+                                + " INT");
+            }
+
+            try {
+                invokeSourceMethod(
+                        source, "validateCachedTableMetadataAfterReconnect", new Class<?>[0]);
+                throw new AssertionError("Expected reconnect metadata validation to reject DDL");
+            } catch (InvocationTargetException e) {
+                assertThat(e.getCause()).isInstanceOf(SQLException.class);
+                assertThat(e.getCause().getMessage())
+                        .contains("Unsupported schema change detected")
+                        .contains("new column");
+            }
+            System.out.printf(
+                    "[OK] Quoted identifiers work and reconnect rejected changed metadata for %s%n",
+                    qualifiedTable);
+        } finally {
+            try (Statement stmt = connection.createStatement()) {
+                stmt.execute("DROP TABLE IF EXISTS " + qualifiedTable);
+            }
+        }
+    }
+
     // ---- Helper methods ----
+
+    @SuppressWarnings("unchecked")
+    private List<WalChange> prepareSourceChanges(
+            GaussDBCDCSourceFunction source, List<WalChange> changes) throws Exception {
+        Method method =
+                GaussDBCDCSourceFunction.class.getDeclaredMethod(
+                        "prepareCommittedWalChanges", List.class);
+        method.setAccessible(true);
+        return (List<WalChange>) method.invoke(source, changes);
+    }
+
+    private void setSourceField(GaussDBCDCSourceFunction source, String name, Object value)
+            throws Exception {
+        Field field = GaussDBCDCSourceFunction.class.getDeclaredField(name);
+        field.setAccessible(true);
+        field.set(source, value);
+    }
+
+    private Object readObjectField(Object target, String name) throws Exception {
+        Field field = target.getClass().getDeclaredField(name);
+        field.setAccessible(true);
+        return field.get(target);
+    }
+
+    private Object invokeSourceMethod(
+            GaussDBCDCSourceFunction source, String name, Class<?>[] parameterTypes, Object... args)
+            throws Exception {
+        Method method = GaussDBCDCSourceFunction.class.getDeclaredMethod(name, parameterTypes);
+        method.setAccessible(true);
+        return method.invoke(source, args);
+    }
 
     private void dropSlotIfExists(String slotName) {
         try (PreparedStatement stmt =

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunctionLifecycleTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunctionLifecycleTest.java
@@ -24,6 +24,7 @@ import org.apache.flink.connector.gaussdbcdc.source.wal.WalChange;
 import org.apache.flink.connector.gaussdbcdc.source.wal.WalReplicationStream;
 import org.apache.flink.runtime.state.FunctionInitializationContext;
 import org.apache.flink.runtime.state.FunctionSnapshotContext;
+import org.apache.flink.streaming.api.functions.source.ParallelSourceFunction;
 import org.apache.flink.streaming.api.functions.source.SourceFunction;
 import org.apache.flink.table.data.RowData;
 
@@ -37,6 +38,7 @@ import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,6 +54,7 @@ import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -98,6 +101,11 @@ class GaussDBCDCSourceFunctionLifecycleTest {
     }
 
     // ---- open() tests ----
+
+    @Test
+    void testSourceSupportsParallelExecution() {
+        assertThat(source).isInstanceOf(ParallelSourceFunction.class);
+    }
 
     @Test
     void testOpenWithPollingMode() throws Exception {
@@ -188,6 +196,123 @@ class GaussDBCDCSourceFunctionLifecycleTest {
         // With running=false immediately, run() should exit without snapshot
         noSnapshotSource.run(mockContext);
         // No exception means it skipped snapshot
+    }
+
+    @Test
+    void testExportSnapshotBoundaryUsesAtomicGaussDbFunction() throws Exception {
+        setField(source, "connection", mockConnection);
+        PreparedStatement probe = mockFunctionProbe(true);
+        when(mockConnection.prepareStatement(contains("FROM pg_catalog.pg_proc")))
+                .thenReturn(probe);
+
+        PreparedStatement isolation = mock(PreparedStatement.class);
+        PreparedStatement export = mock(PreparedStatement.class);
+        ResultSet exportResult = mock(ResultSet.class);
+        when(mockConnection.prepareStatement("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
+                .thenReturn(isolation);
+        when(mockConnection.prepareStatement(
+                        "SELECT * FROM pg_catalog.pg_export_snapshot_and_csn()"))
+                .thenReturn(export);
+        when(export.executeQuery()).thenReturn(exportResult);
+        when(exportResult.next()).thenReturn(true);
+        when(exportResult.getString(1)).thenReturn("00000001-00000002-1");
+        when(exportResult.getString(2)).thenReturn("64");
+
+        Object boundary = invokeExportSnapshotBoundary(source);
+
+        assertThat(readBoundaryField(boundary, "snapshotId")).isEqualTo("00000001-00000002-1");
+        assertThat(readBoundaryField(boundary, "csn")).isEqualTo(100L);
+        verify(mockConnection).setAutoCommit(false);
+    }
+
+    @Test
+    void testExportSnapshotBoundaryFallsBackToStandardSnapshotAndCurrentCsn() throws Exception {
+        setField(source, "connection", mockConnection);
+        PreparedStatement combinedProbe = mockFunctionProbe(false);
+        PreparedStatement csnProbe = mockFunctionProbe(true);
+        when(mockConnection.prepareStatement(contains("FROM pg_catalog.pg_proc")))
+                .thenReturn(combinedProbe, csnProbe);
+
+        PreparedStatement isolation = mock(PreparedStatement.class);
+        PreparedStatement currentCsn = mock(PreparedStatement.class);
+        PreparedStatement export = mock(PreparedStatement.class);
+        ResultSet csnResult = mock(ResultSet.class);
+        ResultSet exportResult = mock(ResultSet.class);
+        when(mockConnection.prepareStatement("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
+                .thenReturn(isolation);
+        when(mockConnection.prepareStatement("SELECT pg_catalog.pg_current_csn()"))
+                .thenReturn(currentCsn);
+        when(currentCsn.executeQuery()).thenReturn(csnResult);
+        when(csnResult.next()).thenReturn(true);
+        when(csnResult.getObject(1)).thenReturn(101L);
+        when(mockConnection.prepareStatement("SELECT pg_catalog.pg_export_snapshot()"))
+                .thenReturn(export);
+        when(export.executeQuery()).thenReturn(exportResult);
+        when(exportResult.next()).thenReturn(true);
+        when(exportResult.getString(1)).thenReturn("00000001-00000003-1");
+
+        Object boundary = invokeExportSnapshotBoundary(source);
+
+        assertThat(readBoundaryField(boundary, "snapshotId")).isEqualTo("00000001-00000003-1");
+        assertThat(readBoundaryField(boundary, "csn")).isEqualTo(101L);
+    }
+
+    @Test
+    void testExportSnapshotBoundaryDisablesCsnFilterWhenOnlyStandardFunctionExists()
+            throws Exception {
+        setField(source, "connection", mockConnection);
+        PreparedStatement combinedProbe = mockFunctionProbe(false);
+        PreparedStatement csnProbe = mockFunctionProbe(false);
+        when(mockConnection.prepareStatement(contains("FROM pg_catalog.pg_proc")))
+                .thenReturn(combinedProbe, csnProbe);
+
+        PreparedStatement isolation = mock(PreparedStatement.class);
+        PreparedStatement export = mock(PreparedStatement.class);
+        ResultSet exportResult = mock(ResultSet.class);
+        when(mockConnection.prepareStatement("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
+                .thenReturn(isolation);
+        when(mockConnection.prepareStatement("SELECT pg_catalog.pg_export_snapshot()"))
+                .thenReturn(export);
+        when(export.executeQuery()).thenReturn(exportResult);
+        when(exportResult.next()).thenReturn(true);
+        when(exportResult.getString(1)).thenReturn("00000001-00000004-1");
+
+        Object boundary = invokeExportSnapshotBoundary(source);
+
+        assertThat(readBoundaryField(boundary, "snapshotId")).isEqualTo("00000001-00000004-1");
+        assertThat(readBoundaryField(boundary, "csn")).isEqualTo(-1L);
+    }
+
+    @Test
+    void testExportSnapshotBoundaryRollsBackFailedAtomicExportBeforeFallback() throws Exception {
+        setField(source, "connection", mockConnection);
+        PreparedStatement combinedProbe = mockFunctionProbe(true);
+        PreparedStatement csnProbe = mockFunctionProbe(false);
+        when(mockConnection.prepareStatement(contains("FROM pg_catalog.pg_proc")))
+                .thenReturn(combinedProbe, csnProbe);
+
+        PreparedStatement isolation = mock(PreparedStatement.class);
+        PreparedStatement combinedExport = mock(PreparedStatement.class);
+        PreparedStatement standardExport = mock(PreparedStatement.class);
+        ResultSet standardResult = mock(ResultSet.class);
+        when(mockConnection.prepareStatement("SET TRANSACTION ISOLATION LEVEL REPEATABLE READ"))
+                .thenReturn(isolation);
+        when(mockConnection.prepareStatement(
+                        "SELECT * FROM pg_catalog.pg_export_snapshot_and_csn()"))
+                .thenReturn(combinedExport);
+        when(combinedExport.executeQuery()).thenThrow(new SQLException("function disappeared"));
+        when(mockConnection.prepareStatement("SELECT pg_catalog.pg_export_snapshot()"))
+                .thenReturn(standardExport);
+        when(standardExport.executeQuery()).thenReturn(standardResult);
+        when(standardResult.next()).thenReturn(true);
+        when(standardResult.getString(1)).thenReturn("00000001-00000005-1");
+
+        Object boundary = invokeExportSnapshotBoundary(source);
+
+        assertThat(readBoundaryField(boundary, "snapshotId")).isEqualTo("00000001-00000005-1");
+        assertThat(readBoundaryField(boundary, "csn")).isEqualTo(-1L);
+        verify(mockConnection).rollback();
+        verify(mockConnection).setAutoCommit(true);
     }
 
     // ---- readSnapshot() tests ----
@@ -284,6 +409,7 @@ class GaussDBCDCSourceFunctionLifecycleTest {
         method.invoke(source, mockContext);
 
         verify(mockContext, atLeastOnce()).collect(any(RowData.class));
+        assertThat(getField(source, "lastConsumedLsn", String.class)).isEqualTo("0/1");
     }
 
     @Test
@@ -351,6 +477,129 @@ class GaussDBCDCSourceFunctionLifecycleTest {
     }
 
     @Test
+    void testSqlWalTransactionAlreadyVisibleInSnapshotIsDiscarded() throws Exception {
+        WalReplicationStream walStream = mock(WalReplicationStream.class);
+        when(walStream.isUseReplicationApi()).thenReturn(false);
+        setField(source, "walReplicationStream", walStream);
+        setField(source, "snapshotCsn", 100L);
+
+        WalChange insert =
+                WalChange.insert(
+                        "0/11",
+                        7,
+                        "public",
+                        TABLE_NAME,
+                        Collections.singletonList(new WalChange.ColumnValue("id", 23, "1", false)));
+        WalChange commit = WalChange.commit("0/12", 7);
+        commit.setCsn(100L);
+
+        List<WalChange> committed =
+                prepareCommittedChanges(
+                        source,
+                        java.util.Arrays.asList(WalChange.begin("0/10", 7, 0), insert, commit));
+
+        assertThat(committed).isEmpty();
+        assertThat(getField(source, "lastCommittedWalLsn", String.class)).isEqualTo("0/12");
+    }
+
+    @Test
+    void testSqlWalTransactionAfterSnapshotIsEmittedAcrossReadBatches() throws Exception {
+        WalReplicationStream walStream = mock(WalReplicationStream.class);
+        when(walStream.isUseReplicationApi()).thenReturn(false);
+        setField(source, "walReplicationStream", walStream);
+        setField(source, "snapshotCsn", 100L);
+
+        WalChange insert =
+                WalChange.insert(
+                        "0/21",
+                        8,
+                        "public",
+                        TABLE_NAME,
+                        Collections.singletonList(new WalChange.ColumnValue("id", 23, "2", false)));
+        assertThat(
+                        prepareCommittedChanges(
+                                source,
+                                java.util.Arrays.asList(WalChange.begin("0/20", 8, 0), insert)))
+                .isEmpty();
+
+        WalChange commit = WalChange.commit("0/22", 8);
+        commit.setCsn(101L);
+        assertThat(prepareCommittedChanges(source, Collections.singletonList(commit)))
+                .containsExactly(insert);
+        assertThat(getField(source, "lastCommittedWalLsn", String.class)).isEqualTo("0/22");
+    }
+
+    @Test
+    void testSqlWalLaterCommitWaitsForEarlierCrossBatchTransaction() throws Exception {
+        WalReplicationStream walStream = mock(WalReplicationStream.class);
+        when(walStream.isUseReplicationApi()).thenReturn(false);
+        setField(source, "walReplicationStream", walStream);
+        setField(source, "snapshotCsn", -1L);
+
+        WalChange delete =
+                WalChange.delete(
+                        "0/11",
+                        7,
+                        "public",
+                        TABLE_NAME,
+                        Collections.singletonList(new WalChange.ColumnValue("id", 23, "1", false)));
+        assertThat(
+                        prepareCommittedChanges(
+                                source,
+                                java.util.Arrays.asList(WalChange.begin("0/10", 7, 0), delete)))
+                .isEmpty();
+
+        WalChange insert =
+                WalChange.insert(
+                        "0/21",
+                        8,
+                        "public",
+                        TABLE_NAME,
+                        Collections.singletonList(new WalChange.ColumnValue("id", 23, "2", false)));
+        WalChange insertCommit = WalChange.commit("0/22", 8);
+        insertCommit.setCsn(102L);
+        assertThat(
+                        prepareCommittedChanges(
+                                source,
+                                java.util.Arrays.asList(
+                                        WalChange.begin("0/20", 8, 0), insert, insertCommit)))
+                .isEmpty();
+        assertThat(getField(source, "lastCommittedWalLsn", String.class)).isNull();
+
+        WalChange deleteCommit = WalChange.commit("0/30", 7);
+        deleteCommit.setCsn(101L);
+        assertThat(prepareCommittedChanges(source, Collections.singletonList(deleteCommit)))
+                .containsExactly(delete, insert);
+        assertThat(getField(source, "lastCommittedWalLsn", String.class)).isEqualTo("0/30");
+    }
+
+    @Test
+    void testSqlWalDeduplicatesByCommitLsnNotDeleteDataLsn() throws Exception {
+        WalReplicationStream walStream = mock(WalReplicationStream.class);
+        when(walStream.isUseReplicationApi()).thenReturn(false);
+        setField(source, "walReplicationStream", walStream);
+        setField(source, "lastConsumedLsn", "0/15");
+
+        WalChange delete =
+                WalChange.delete(
+                        "0/11",
+                        9,
+                        "public",
+                        TABLE_NAME,
+                        Collections.singletonList(new WalChange.ColumnValue("id", 23, "1", false)));
+        WalChange commit = WalChange.commit("0/20", 9);
+        commit.setCsn(103L);
+
+        assertThat(
+                        prepareCommittedChanges(
+                                source,
+                                java.util.Arrays.asList(
+                                        WalChange.begin("0/10", 9, 0), delete, commit)))
+                .containsExactly(delete);
+        assertThat(getField(source, "lastCommittedWalLsn", String.class)).isEqualTo("0/20");
+    }
+
+    @Test
     void testRunWalStreamingWithDeleteChange() throws Exception {
         cacheTestTableColumns();
         WalReplicationStream walStream = mock(WalReplicationStream.class);
@@ -386,6 +635,16 @@ class GaussDBCDCSourceFunctionLifecycleTest {
         verify(mockContext, atLeastOnce()).collect(any(RowData.class));
     }
 
+    @SuppressWarnings("unchecked")
+    private static List<WalChange> prepareCommittedChanges(
+            GaussDBCDCSourceFunction source, List<WalChange> changes) throws Exception {
+        Method method =
+                GaussDBCDCSourceFunction.class.getDeclaredMethod(
+                        "prepareCommittedWalChanges", List.class);
+        method.setAccessible(true);
+        return (List<WalChange>) method.invoke(source, changes);
+    }
+
     @Test
     void testRunWalStreamingInitializeStream() throws Exception {
         WalReplicationStream walStream = mock(WalReplicationStream.class);
@@ -408,6 +667,7 @@ class GaussDBCDCSourceFunctionLifecycleTest {
         method.invoke(source, mockContext);
 
         verify(walStream).initialize();
+        verify(walStream, never()).readChanges(10000);
         assertThat(getField(source, "walStreamInitialized", boolean.class)).isTrue();
     }
 
@@ -602,6 +862,30 @@ class GaussDBCDCSourceFunctionLifecycleTest {
     }
 
     @Test
+    void testWalLsnAcknowledgedOnlyAfterCheckpointCompletes() throws Exception {
+        WalReplicationStream walStream = mock(WalReplicationStream.class);
+        setField(source, "walReplicationStream", walStream);
+        setField(source, "walStreamInitialized", true);
+        setField(source, "lastConsumedLsn", "0/20");
+
+        ListState<String> mockState = mock(ListState.class);
+        setField(source, "offsetState", mockState);
+        FunctionSnapshotContext snapshotContext = mock(FunctionSnapshotContext.class);
+        when(snapshotContext.getCheckpointId()).thenReturn(42L);
+
+        source.snapshotState(snapshotContext);
+        verify(walStream, never()).acknowledgeLsn(anyString());
+
+        source.notifyCheckpointComplete(42L);
+        verify(walStream).acknowledgeLsn("0/20");
+
+        when(snapshotContext.getCheckpointId()).thenReturn(43L);
+        source.snapshotState(snapshotContext);
+        source.notifyCheckpointComplete(43L);
+        verify(walStream, times(1)).acknowledgeLsn("0/20");
+    }
+
+    @Test
     void testSnapshotStateWithNullLsn() throws Exception {
         WalReplicationStream walStream = mock(WalReplicationStream.class);
         when(walStream.getLastLsn()).thenReturn(null);
@@ -648,10 +932,36 @@ class GaussDBCDCSourceFunctionLifecycleTest {
     }
 
     @Test
+    void testSnapshotStatePersistsPollingStateOnActiveSubtask() throws Exception {
+        ListState<String> offset = mock(ListState.class);
+        ListState<byte[]> polling = mock(ListState.class);
+        ChangeDataPoller poller = mock(ChangeDataPoller.class);
+        byte[] serialized = new byte[] {1, 2, 3};
+        when(poller.serializeState()).thenReturn(serialized);
+        setField(source, "offsetState", offset);
+        setField(source, "pollingState", polling);
+        setField(source, "changeDataPoller", poller);
+
+        org.apache.flink.api.common.functions.RuntimeContext runtimeContext =
+                mock(org.apache.flink.api.common.functions.RuntimeContext.class);
+        when(runtimeContext.getIndexOfThisSubtask()).thenReturn(0);
+        Field rtCtxField =
+                org.apache.flink.api.common.functions.AbstractRichFunction.class.getDeclaredField(
+                        "runtimeContext");
+        rtCtxField.setAccessible(true);
+        rtCtxField.set(source, runtimeContext);
+
+        source.snapshotState(mock(FunctionSnapshotContext.class));
+
+        verify(polling).clear();
+        verify(polling).add(serialized);
+    }
+
+    @Test
     void testInitializeStateNotRestored() throws Exception {
         OperatorStateStore stateStore = mock(OperatorStateStore.class);
         ListState<String> mockListState = mock(ListState.class);
-        org.mockito.Mockito.doReturn(mockListState).when(stateStore).getListState(any());
+        org.mockito.Mockito.doReturn(mockListState).when(stateStore).getUnionListState(any());
 
         FunctionInitializationContext initContext = mock(FunctionInitializationContext.class);
         when(initContext.isRestored()).thenReturn(false);
@@ -659,7 +969,7 @@ class GaussDBCDCSourceFunctionLifecycleTest {
 
         source.initializeState(initContext);
 
-        verify(stateStore).getListState(any());
+        verify(stateStore, times(2)).getUnionListState(any());
         assertThat(getField(source, "offsetState", ListState.class)).isNotNull();
     }
 
@@ -667,11 +977,15 @@ class GaussDBCDCSourceFunctionLifecycleTest {
     void testInitializeStateRestoredWithLsn() throws Exception {
         OperatorStateStore stateStore = mock(OperatorStateStore.class);
         ListState<String> mockListState = mock(ListState.class);
-        org.mockito.Mockito.doReturn(mockListState).when(stateStore).getListState(any());
+        ListState<byte[]> mockPollingState = mock(ListState.class);
+        org.mockito.Mockito.doReturn(mockListState, mockPollingState)
+                .when(stateStore)
+                .getUnionListState(any());
 
         List<String> restoredLsns = new ArrayList<>();
         restoredLsns.add("0/15A3B");
         when(mockListState.get()).thenReturn(restoredLsns);
+        when(mockPollingState.get()).thenReturn(Collections.emptyList());
 
         FunctionInitializationContext initContext = mock(FunctionInitializationContext.class);
         when(initContext.isRestored()).thenReturn(true);
@@ -680,6 +994,7 @@ class GaussDBCDCSourceFunctionLifecycleTest {
         source.initializeState(initContext);
 
         verify(mockListState).get();
+        assertThat(getField(source, "restoredLsn", String.class)).isEqualTo("0/15A3B");
     }
 
     // ---- convertToRowDataDynamic extended tests ----
@@ -922,12 +1237,21 @@ class GaussDBCDCSourceFunctionLifecycleTest {
         when(columnsRs.getString("COLUMN_NAME")).thenReturn("id", "name");
 
         setField(source, "connection", mockConnection);
+        Map<String, String> cachedPk = new HashMap<>();
+        cachedPk.put(TABLE_NAME, "id");
+        setField(source, "cachedPkByTable", cachedPk);
 
         if (numSubtasks > 1) {
+            ResultSet typeRs = mock(ResultSet.class);
+            when(dbMeta.getColumns(null, "public", "test_table", null))
+                    .thenReturn(columnsRs, typeRs);
+            when(typeRs.next()).thenReturn(true);
+            when(typeRs.getString("COLUMN_NAME")).thenReturn("id");
+            when(typeRs.getInt("DATA_TYPE")).thenReturn(Types.INTEGER);
             // Mock getIdRange
             PreparedStatement idRangeStmt = mock(PreparedStatement.class);
             ResultSet idRangeRs = mock(ResultSet.class);
-            when(mockConnection.prepareStatement(contains("MIN(id)"))).thenReturn(idRangeStmt);
+            when(mockConnection.prepareStatement(contains("MIN(\"id\")"))).thenReturn(idRangeStmt);
             when(idRangeStmt.executeQuery()).thenReturn(idRangeRs);
             when(idRangeRs.next()).thenReturn(true);
             when(idRangeRs.getLong(1)).thenReturn(1L);
@@ -937,7 +1261,8 @@ class GaussDBCDCSourceFunctionLifecycleTest {
             // Mock SELECT with WHERE
             PreparedStatement selectStmt = mock(PreparedStatement.class);
             ResultSet selectRs = mock(ResultSet.class);
-            when(mockConnection.prepareStatement(contains("WHERE id >= ?"))).thenReturn(selectStmt);
+            when(mockConnection.prepareStatement(contains("WHERE \"id\" >= ?")))
+                    .thenReturn(selectStmt);
             when(selectStmt.executeQuery()).thenReturn(selectRs);
             when(selectRs.next()).thenReturn(true, false);
 
@@ -953,7 +1278,8 @@ class GaussDBCDCSourceFunctionLifecycleTest {
             // Single subtask: SELECT without WHERE
             PreparedStatement selectStmt = mock(PreparedStatement.class);
             ResultSet selectRs = mock(ResultSet.class);
-            when(mockConnection.prepareStatement(contains("ORDER BY id"))).thenReturn(selectStmt);
+            when(mockConnection.prepareStatement(contains("ORDER BY \"id\"")))
+                    .thenReturn(selectStmt);
             when(selectStmt.executeQuery()).thenReturn(selectRs);
             when(selectRs.next()).thenReturn(true, false);
 
@@ -988,11 +1314,19 @@ class GaussDBCDCSourceFunctionLifecycleTest {
         when(columnsRs.getString("COLUMN_NAME")).thenReturn("id", "name");
 
         setField(source, "connection", mockConnection);
+        Map<String, String> cachedPk = new HashMap<>();
+        cachedPk.put(TABLE_NAME, "id");
+        setField(source, "cachedPkByTable", cachedPk);
+        ResultSet typeRs = mock(ResultSet.class);
+        when(dbMeta.getColumns(null, "public", "test_table", null)).thenReturn(columnsRs, typeRs);
+        when(typeRs.next()).thenReturn(true);
+        when(typeRs.getString("COLUMN_NAME")).thenReturn("id");
+        when(typeRs.getInt("DATA_TYPE")).thenReturn(Types.INTEGER);
 
         // Empty table - getIdRange returns [0, -1]
         PreparedStatement idRangeStmt = mock(PreparedStatement.class);
         ResultSet idRangeRs = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(contains("MIN(id)"))).thenReturn(idRangeStmt);
+        when(mockConnection.prepareStatement(contains("MIN(\"id\")"))).thenReturn(idRangeStmt);
         when(idRangeStmt.executeQuery()).thenReturn(idRangeRs);
         when(idRangeRs.next()).thenReturn(true);
         when(idRangeRs.getLong(1)).thenReturn(0L);
@@ -1002,9 +1336,31 @@ class GaussDBCDCSourceFunctionLifecycleTest {
         // SELECT with WHERE (empty results)
         PreparedStatement selectStmt = mock(PreparedStatement.class);
         ResultSet selectRs = mock(ResultSet.class);
-        when(mockConnection.prepareStatement(contains("WHERE id >= ?"))).thenReturn(selectStmt);
+        when(mockConnection.prepareStatement(contains("WHERE \"id\" >= ?"))).thenReturn(selectStmt);
         when(selectStmt.executeQuery()).thenReturn(selectRs);
         when(selectRs.next()).thenReturn(false);
+    }
+
+    private static PreparedStatement mockFunctionProbe(boolean available) throws Exception {
+        PreparedStatement probe = mock(PreparedStatement.class);
+        ResultSet result = mock(ResultSet.class);
+        when(probe.executeQuery()).thenReturn(result);
+        when(result.next()).thenReturn(true);
+        when(result.getBoolean(1)).thenReturn(available);
+        return probe;
+    }
+
+    private static Object invokeExportSnapshotBoundary(GaussDBCDCSourceFunction target)
+            throws Exception {
+        Method method = GaussDBCDCSourceFunction.class.getDeclaredMethod("exportSnapshotBoundary");
+        method.setAccessible(true);
+        return method.invoke(target);
+    }
+
+    private static Object readBoundaryField(Object boundary, String fieldName) throws Exception {
+        Field field = boundary.getClass().getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return field.get(boundary);
     }
 
     private static void setField(Object target, String fieldName, Object value) throws Exception {

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunctionLifecycleTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunctionLifecycleTest.java
@@ -40,7 +40,9 @@ import java.sql.ResultSetMetaData;
 import java.sql.Types;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
@@ -56,6 +58,8 @@ import static org.mockito.Mockito.when;
 /** Comprehensive tests for {@link GaussDBCDCSourceFunction} lifecycle and runtime methods. */
 class GaussDBCDCSourceFunctionLifecycleTest {
 
+    private static final String TABLE_NAME = "test_table";
+
     private GaussDBCDCSourceFunction source;
     private Connection mockConnection;
     private SourceFunction.SourceContext<RowData> mockContext;
@@ -68,6 +72,29 @@ class GaussDBCDCSourceFunctionLifecycleTest {
         mockContext = mock(SourceFunction.SourceContext.class);
         checkpointLock = new Object();
         when(mockContext.getCheckpointLock()).thenReturn(checkpointLock);
+        // Multi-table support: initialize per-table cache maps used by readSnapshot
+        // and convertWalColumnsToRowData. open() normally does this but the tests
+        // bypass open(), so we set the fields here via reflection.
+        try {
+            setField(source, "cachedColumnsByTable", new HashMap<String, List<String>>());
+            setField(source, "cachedPkByTable", new HashMap<String, String>());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /** Pre-populate column cache for a table, used by WAL streaming tests. */
+    @SuppressWarnings("unchecked")
+    private void cacheTestTableColumns() throws Exception {
+        Map<String, List<String>> colsMap =
+                (Map<String, List<String>>) getField(source, "cachedColumnsByTable", Map.class);
+        List<String> cols = new ArrayList<>();
+        cols.add("id");
+        colsMap.put("test_table", cols);
+
+        Map<String, String> pkMap =
+                (Map<String, String>) getField(source, "cachedPkByTable", Map.class);
+        pkMap.put("test_table", "id");
     }
 
     // ---- open() tests ----
@@ -172,9 +199,9 @@ class GaussDBCDCSourceFunctionLifecycleTest {
 
         Method method =
                 GaussDBCDCSourceFunction.class.getDeclaredMethod(
-                        "readSnapshot", SourceFunction.SourceContext.class);
+                        "readSnapshot", SourceFunction.SourceContext.class, String.class);
         method.setAccessible(true);
-        method.invoke(source, mockContext);
+        method.invoke(source, mockContext, TABLE_NAME);
 
         verify(mockContext, atLeastOnce()).collect(any(RowData.class));
     }
@@ -186,9 +213,9 @@ class GaussDBCDCSourceFunctionLifecycleTest {
 
         Method method =
                 GaussDBCDCSourceFunction.class.getDeclaredMethod(
-                        "readSnapshot", SourceFunction.SourceContext.class);
+                        "readSnapshot", SourceFunction.SourceContext.class, String.class);
         method.setAccessible(true);
-        method.invoke(source, mockContext);
+        method.invoke(source, mockContext, TABLE_NAME);
 
         verify(mockContext, atLeastOnce()).collect(any(RowData.class));
     }
@@ -200,9 +227,9 @@ class GaussDBCDCSourceFunctionLifecycleTest {
 
         Method method =
                 GaussDBCDCSourceFunction.class.getDeclaredMethod(
-                        "readSnapshot", SourceFunction.SourceContext.class);
+                        "readSnapshot", SourceFunction.SourceContext.class, String.class);
         method.setAccessible(true);
-        method.invoke(source, mockContext);
+        method.invoke(source, mockContext, TABLE_NAME);
 
         verify(mockContext, atLeastOnce()).collect(any(RowData.class));
     }
@@ -213,9 +240,9 @@ class GaussDBCDCSourceFunctionLifecycleTest {
 
         Method method =
                 GaussDBCDCSourceFunction.class.getDeclaredMethod(
-                        "readSnapshot", SourceFunction.SourceContext.class);
+                        "readSnapshot", SourceFunction.SourceContext.class, String.class);
         method.setAccessible(true);
-        method.invoke(source, mockContext);
+        method.invoke(source, mockContext, TABLE_NAME);
 
         verify(mockContext, never()).collect(any(RowData.class));
     }
@@ -224,6 +251,7 @@ class GaussDBCDCSourceFunctionLifecycleTest {
 
     @Test
     void testRunWalStreamingWithInsertChange() throws Exception {
+        cacheTestTableColumns();
         WalReplicationStream walStream = mock(WalReplicationStream.class);
         List<WalChange> changes = new ArrayList<>();
         WalChange insert =
@@ -260,6 +288,7 @@ class GaussDBCDCSourceFunctionLifecycleTest {
 
     @Test
     void testRunWalStreamingWithUpdateChange() throws Exception {
+        cacheTestTableColumns();
         WalReplicationStream walStream = mock(WalReplicationStream.class);
         List<WalChange> changes = new ArrayList<>();
         WalChange update =
@@ -323,6 +352,7 @@ class GaussDBCDCSourceFunctionLifecycleTest {
 
     @Test
     void testRunWalStreamingWithDeleteChange() throws Exception {
+        cacheTestTableColumns();
         WalReplicationStream walStream = mock(WalReplicationStream.class);
         List<WalChange> changes = new ArrayList<>();
         WalChange delete =

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunctionRuntimeTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunctionRuntimeTest.java
@@ -24,18 +24,23 @@ import org.apache.flink.table.data.RowData;
 import org.junit.jupiter.api.Test;
 
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
+import java.sql.SQLException;
 import java.sql.Types;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -142,6 +147,35 @@ class GaussDBCDCSourceFunctionRuntimeTest {
         assertThat(row.getArity()).isEqualTo(4);
     }
 
+    @Test
+    void testHeSelectsCustomizedJsonFormat() throws Exception {
+        GaussDBCDCSourceFunction source = createJsonSource("he");
+        Method method =
+                GaussDBCDCSourceFunction.class.getDeclaredMethod(
+                        "convertWalChangeToJson", WalChange.class);
+        method.setAccessible(true);
+        WalChange change =
+                WalChange.insert(
+                        "0/10",
+                        1L,
+                        "public",
+                        "test_table",
+                        Collections.singletonList(new WalChange.ColumnValue("id", 23, "7", false)));
+
+        RowData row = (RowData) method.invoke(source, change);
+        assertThat(row.getString(0).toString())
+                .contains("\"optType\":\"INSERT\"")
+                .contains("\"pkValues\":\"7\"")
+                .doesNotContain("\"op\":");
+    }
+
+    @Test
+    void testOldHaierSelectorIsNoLongerAccepted() throws Exception {
+        assertThatIllegalArgumentException()
+                .isThrownBy(() -> createJsonSource("haier"))
+                .withMessageContaining("Unsupported output.json.format");
+    }
+
     /** Test convertWalColumnsToRowData with null column. */
     @Test
     void testConvertWalColumnsToRowDataWithNull() throws Exception {
@@ -199,7 +233,46 @@ class GaussDBCDCSourceFunctionRuntimeTest {
         method.setAccessible(true);
 
         String result = (String) method.invoke(source, "test_table");
-        assertThat(result).isEqualTo("id, name");
+        assertThat(result).isEqualTo("\"id\", \"name\"");
+    }
+
+    @Test
+    void testReconnectMetadataValidationAcceptsUnchangedColumns() throws Exception {
+        GaussDBCDCSourceFunction source = sourceWithCachedColumns(Arrays.asList("id", "name"));
+        Connection conn = mock(Connection.class);
+        DatabaseMetaData meta = mock(DatabaseMetaData.class);
+        ResultSet columnsRs = mock(ResultSet.class);
+        when(conn.getMetaData()).thenReturn(meta);
+        when(meta.getColumns(null, "public", "test_table", null)).thenReturn(columnsRs);
+        when(columnsRs.next()).thenReturn(true, true, false);
+        when(columnsRs.getString("COLUMN_NAME")).thenReturn("id", "name");
+        setConnection(source, conn);
+
+        reconnectMetadataValidationMethod().invoke(source);
+    }
+
+    @Test
+    void testReconnectMetadataValidationFailsFastOnDdl() throws Exception {
+        GaussDBCDCSourceFunction source = sourceWithCachedColumns(Arrays.asList("id", "name"));
+        Connection conn = mock(Connection.class);
+        DatabaseMetaData meta = mock(DatabaseMetaData.class);
+        ResultSet columnsRs = mock(ResultSet.class);
+        when(conn.getMetaData()).thenReturn(meta);
+        when(meta.getColumns(null, "public", "test_table", null)).thenReturn(columnsRs);
+        when(columnsRs.next()).thenReturn(true, true, true, false);
+        when(columnsRs.getString("COLUMN_NAME")).thenReturn("id", "name", "new_column");
+        setConnection(source, conn);
+
+        try {
+            reconnectMetadataValidationMethod().invoke(source);
+            throw new AssertionError("Expected schema evolution validation to fail");
+        } catch (InvocationTargetException e) {
+            assertThat(e.getCause()).isInstanceOf(SQLException.class);
+            assertThat(e.getCause().getMessage())
+                    .contains("Unsupported schema change detected")
+                    .contains("new_column")
+                    .contains("restart");
+        }
     }
 
     /** Test getIdRange via reflection with mocked connection. */
@@ -454,6 +527,57 @@ class GaussDBCDCSourceFunctionRuntimeTest {
                 .username("root")
                 .password("pass")
                 .build();
+    }
+
+    private GaussDBCDCSourceFunction createJsonSource(String jsonFormat) throws Exception {
+        GaussDBCDCSourceFunction source =
+                GaussDBCDCSourceFunction.builder()
+                        .hostname("localhost")
+                        .port(8000)
+                        .database("testdb")
+                        .schema("public")
+                        .tableName("test_table")
+                        .username("root")
+                        .password("pass")
+                        .outputFormat("json")
+                        .outputJsonFormat(jsonFormat)
+                        .build();
+        initTransientMaps(source);
+        Field pkField = GaussDBCDCSourceFunction.class.getDeclaredField("cachedPkByTable");
+        pkField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, String> primaryKeys = (Map<String, String>) pkField.get(source);
+        primaryKeys.put("test_table", "id");
+        return source;
+    }
+
+    private GaussDBCDCSourceFunction sourceWithCachedColumns(List<String> columns)
+            throws Exception {
+        GaussDBCDCSourceFunction source = createMinimalSource();
+        initTransientMaps(source);
+        Field columnsField =
+                GaussDBCDCSourceFunction.class.getDeclaredField("cachedColumnsByTable");
+        columnsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, List<String>> columnsByTable =
+                (Map<String, List<String>>) columnsField.get(source);
+        columnsByTable.put("test_table", new ArrayList<>(columns));
+        return source;
+    }
+
+    private void setConnection(GaussDBCDCSourceFunction source, Connection connection)
+            throws Exception {
+        Field connectionField = GaussDBCDCSourceFunction.class.getDeclaredField("connection");
+        connectionField.setAccessible(true);
+        connectionField.set(source, connection);
+    }
+
+    private Method reconnectMetadataValidationMethod() throws Exception {
+        Method method =
+                GaussDBCDCSourceFunction.class.getDeclaredMethod(
+                        "validateCachedTableMetadataAfterReconnect");
+        method.setAccessible(true);
+        return method;
     }
 
     /** Initialize transient Map fields that are normally set in open(). */

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunctionRuntimeTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/GaussDBCDCSourceFunctionRuntimeTest.java
@@ -102,17 +102,31 @@ class GaussDBCDCSourceFunctionRuntimeTest {
     @Test
     void testConvertWalColumnsToRowData() throws Exception {
         GaussDBCDCSourceFunction source = createMinimalSource();
+        initTransientMaps(source);
+        // Pre-populate column cache for test_table so convertWalColumnsToRowData finds it
+        java.lang.reflect.Field colsField =
+                GaussDBCDCSourceFunction.class.getDeclaredField("cachedColumnsByTable");
+        colsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, java.util.List<String>> colsMap =
+                (java.util.Map<String, java.util.List<String>>) colsField.get(source);
+        java.util.List<String> cols = new ArrayList<>();
+        cols.add("id");
+        cols.add("name");
+        cols.add("age");
+        cols.add("score");
+        colsMap.put("test_table", cols);
         Method method =
                 GaussDBCDCSourceFunction.class.getDeclaredMethod(
-                        "convertWalColumnsToRowData", List.class);
+                        "convertWalColumnsToRowData", List.class, String.class);
         method.setAccessible(true);
 
         // Null list
-        Object result = method.invoke(source, (Object) null);
+        Object result = method.invoke(source, (Object) null, "test_table");
         assertThat(result).isNull();
 
         // Empty list
-        result = method.invoke(source, Collections.emptyList());
+        result = method.invoke(source, Collections.emptyList(), "test_table");
         assertThat(result).isNull();
 
         // List with values
@@ -122,7 +136,7 @@ class GaussDBCDCSourceFunctionRuntimeTest {
         columns.add(new WalChange.ColumnValue("age", 23, "20", false));
         columns.add(new WalChange.ColumnValue("score", 701, "95.5", false));
 
-        result = method.invoke(source, columns);
+        result = method.invoke(source, columns, "test_table");
         assertThat(result).isInstanceOf(RowData.class);
         RowData row = (RowData) result;
         assertThat(row.getArity()).isEqualTo(4);
@@ -132,16 +146,28 @@ class GaussDBCDCSourceFunctionRuntimeTest {
     @Test
     void testConvertWalColumnsToRowDataWithNull() throws Exception {
         GaussDBCDCSourceFunction source = createMinimalSource();
+        initTransientMaps(source);
+        // Pre-populate column cache for test_table
+        java.lang.reflect.Field colsField =
+                GaussDBCDCSourceFunction.class.getDeclaredField("cachedColumnsByTable");
+        colsField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        java.util.Map<String, java.util.List<String>> colsMap =
+                (java.util.Map<String, java.util.List<String>>) colsField.get(source);
+        java.util.List<String> cols = new ArrayList<>();
+        cols.add("id");
+        cols.add("name");
+        colsMap.put("test_table", cols);
         Method method =
                 GaussDBCDCSourceFunction.class.getDeclaredMethod(
-                        "convertWalColumnsToRowData", List.class);
+                        "convertWalColumnsToRowData", List.class, String.class);
         method.setAccessible(true);
 
         List<WalChange.ColumnValue> columns = new ArrayList<>();
         columns.add(new WalChange.ColumnValue("id", 23, "1", false));
         columns.add(new WalChange.ColumnValue("name", 25, null, true));
 
-        Object result = method.invoke(source, columns);
+        Object result = method.invoke(source, columns, "test_table");
         assertThat(result).isInstanceOf(RowData.class);
         RowData row = (RowData) result;
         assertThat(row.getArity()).isEqualTo(2);
@@ -151,6 +177,7 @@ class GaussDBCDCSourceFunctionRuntimeTest {
     @Test
     void testGetTableColumns() throws Exception {
         GaussDBCDCSourceFunction source = createMinimalSource();
+        initTransientMaps(source);
 
         // Mock connection
         Connection conn = mock(Connection.class);
@@ -167,10 +194,11 @@ class GaussDBCDCSourceFunctionRuntimeTest {
         connField.setAccessible(true);
         connField.set(source, conn);
 
-        Method method = GaussDBCDCSourceFunction.class.getDeclaredMethod("getTableColumns");
+        Method method =
+                GaussDBCDCSourceFunction.class.getDeclaredMethod("getTableColumns", String.class);
         method.setAccessible(true);
 
-        String result = (String) method.invoke(source);
+        String result = (String) method.invoke(source, "test_table");
         assertThat(result).isEqualTo("id, name");
     }
 
@@ -194,10 +222,12 @@ class GaussDBCDCSourceFunctionRuntimeTest {
         connField.setAccessible(true);
         connField.set(source, conn);
 
-        Method method = GaussDBCDCSourceFunction.class.getDeclaredMethod("getIdRange");
+        Method method =
+                GaussDBCDCSourceFunction.class.getDeclaredMethod(
+                        "getIdRange", String.class, String.class);
         method.setAccessible(true);
 
-        long[] result = (long[]) method.invoke(source);
+        long[] result = (long[]) method.invoke(source, "test_table", "id");
         assertThat(result).containsExactly(1L, 1000L);
     }
 
@@ -220,10 +250,12 @@ class GaussDBCDCSourceFunctionRuntimeTest {
         connField.setAccessible(true);
         connField.set(source, conn);
 
-        Method method = GaussDBCDCSourceFunction.class.getDeclaredMethod("getIdRange");
+        Method method =
+                GaussDBCDCSourceFunction.class.getDeclaredMethod(
+                        "getIdRange", String.class, String.class);
         method.setAccessible(true);
 
-        long[] result = (long[]) method.invoke(source);
+        long[] result = (long[]) method.invoke(source, "test_table", "id");
         assertThat(result).containsExactly(0L, -1L);
     }
 
@@ -422,5 +454,18 @@ class GaussDBCDCSourceFunctionRuntimeTest {
                 .username("root")
                 .password("pass")
                 .build();
+    }
+
+    /** Initialize transient Map fields that are normally set in open(). */
+    private void initTransientMaps(GaussDBCDCSourceFunction source) throws Exception {
+        java.lang.reflect.Field colsField =
+                GaussDBCDCSourceFunction.class.getDeclaredField("cachedColumnsByTable");
+        colsField.setAccessible(true);
+        colsField.set(source, new java.util.HashMap<>());
+
+        java.lang.reflect.Field pkField =
+                GaussDBCDCSourceFunction.class.getDeclaredField("cachedPkByTable");
+        pkField.setAccessible(true);
+        pkField.set(source, new java.util.HashMap<>());
     }
 }

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/SqlIdentifierUtilsTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/SqlIdentifierUtilsTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.gaussdbcdc.source;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
+
+class SqlIdentifierUtilsTest {
+
+    @Test
+    void testQuotesReservedMixedCaseAndEmbeddedQuoteIdentifiers() {
+        assertThat(SqlIdentifierUtils.quote("order")).isEqualTo("\"order\"");
+        assertThat(SqlIdentifierUtils.quote("Order Detail")).isEqualTo("\"Order Detail\"");
+        assertThat(SqlIdentifierUtils.quote("a\"b")).isEqualTo("\"a\"\"b\"");
+        assertThat(SqlIdentifierUtils.quote("a`b", "`")).isEqualTo("`a``b`");
+        assertThat(SqlIdentifierUtils.qualified("Mixed Schema", "order"))
+                .isEqualTo("\"Mixed Schema\".\"order\"");
+        assertThat(SqlIdentifierUtils.columnList(Arrays.asList("id", "select", "a\"b")))
+                .isEqualTo("\"id\", \"select\", \"a\"\"b\"");
+    }
+
+    @Test
+    void testRejectsNullIdentifier() {
+        assertThatIllegalArgumentException().isThrownBy(() -> SqlIdentifierUtils.quote(null));
+    }
+}

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/wal/WalReplicationStreamAdditionalTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/wal/WalReplicationStreamAdditionalTest.java
@@ -30,6 +30,7 @@ import java.sql.SQLException;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -283,8 +284,31 @@ class WalReplicationStreamAdditionalTest {
         Method method = WalReplicationStream.class.getDeclaredMethod("advanceSlot");
         method.setAccessible(true);
 
-        // Should not throw, just log warning
-        method.invoke(stream);
+        assertThatThrownBy(() -> method.invoke(stream))
+                .hasCauseInstanceOf(SQLException.class)
+                .hasRootCauseMessage("not found");
+    }
+
+    @Test
+    void testFailedCheckpointAcknowledgeRetainsSqlPeekPrefix() throws Exception {
+        PreparedStatement gaussdbStmt = mock(PreparedStatement.class);
+        when(gaussdbStmt.execute()).thenThrow(new SQLException("not found"));
+        when(connection.prepareStatement("SELECT pg_replication_slot_advance(?, ?)"))
+                .thenReturn(gaussdbStmt);
+        PreparedStatement postgresStmt = mock(PreparedStatement.class);
+        when(postgresStmt.execute()).thenThrow(new SQLException("not found"));
+        when(connection.prepareStatement("SELECT pg_logical_slot_advance(?, ?)"))
+                .thenReturn(postgresStmt);
+
+        WalReplicationStream stream = createStream(1);
+        Field pendingField = WalReplicationStream.class.getDeclaredField("sqlUnacknowledgedLsns");
+        pendingField.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        List<String> pending = (List<String>) pendingField.get(stream);
+        pending.add("0/15A3B");
+
+        assertThatThrownBy(() -> stream.acknowledgeLsn("0/15A3B")).isInstanceOf(SQLException.class);
+        assertThat(pending).containsExactly("0/15A3B");
     }
 
     // ---- getCurrentLsn tests ----

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/wal/WalReplicationStreamTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/source/wal/WalReplicationStreamTest.java
@@ -87,7 +87,7 @@ class WalReplicationStreamTest {
 
         // Mock createSlot
         PreparedStatement createStmt = mock(PreparedStatement.class);
-        when(connection.prepareStatement("SELECT pg_create_logical_replication_slot(?, ?)"))
+        when(connection.prepareStatement("SELECT * FROM pg_create_logical_replication_slot(?, ?)"))
                 .thenReturn(createStmt);
 
         // Mock getCurrentLsn
@@ -114,6 +114,40 @@ class WalReplicationStreamTest {
 
         assertThat(stream.isRunning()).isTrue();
         assertThat(stream.getLastLsn()).isEqualTo("0/0");
+    }
+
+    @Test
+    void testPrepareSlotForSnapshotReturnsCreationLsn() throws Exception {
+        PreparedStatement checkStmt = mock(PreparedStatement.class);
+        ResultSet checkRs = mock(ResultSet.class);
+        when(checkStmt.executeQuery()).thenReturn(checkRs);
+        when(checkRs.next()).thenReturn(false);
+        when(connection.prepareStatement("SELECT 1 FROM pg_replication_slots WHERE slot_name = ?"))
+                .thenReturn(checkStmt);
+
+        PreparedStatement createStmt = mock(PreparedStatement.class);
+        ResultSet createRs = mock(ResultSet.class);
+        when(createStmt.execute()).thenReturn(true);
+        when(createStmt.getResultSet()).thenReturn(createRs);
+        when(createRs.next()).thenReturn(true);
+        when(createRs.getString(2)).thenReturn("0/ABC");
+        when(connection.prepareStatement("SELECT * FROM pg_create_logical_replication_slot(?, ?)"))
+                .thenReturn(createStmt);
+
+        WalReplicationStream stream =
+                new WalReplicationStream(
+                        connection,
+                        "jdbc:gaussdb://localhost:8000/test",
+                        "root",
+                        "pass",
+                        "test_slot",
+                        "pgoutput",
+                        1,
+                        "b",
+                        false,
+                        1000);
+
+        assertThat(stream.prepareSlotForSnapshot()).isEqualTo("0/ABC");
     }
 
     @Test

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactoryCreateTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactoryCreateTest.java
@@ -19,6 +19,7 @@
 package org.apache.flink.connector.gaussdbcdc.table;
 
 import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.api.ValidationException;
 import org.apache.flink.table.catalog.CatalogTable;
 import org.apache.flink.table.catalog.Column;
 import org.apache.flink.table.catalog.ObjectIdentifier;
@@ -26,6 +27,7 @@ import org.apache.flink.table.catalog.ResolvedCatalogTable;
 import org.apache.flink.table.catalog.ResolvedSchema;
 import org.apache.flink.table.catalog.UniqueConstraint;
 import org.apache.flink.table.connector.source.DynamicTableSource;
+import org.apache.flink.table.connector.source.SourceFunctionProvider;
 import org.apache.flink.table.factories.DynamicTableFactory;
 
 import org.junit.jupiter.api.Test;
@@ -37,6 +39,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
@@ -52,7 +55,7 @@ class GaussDBCDCTableSourceFactoryCreateTest {
     }
 
     @Test
-    void testCreateDynamicTableSourceWithAllOptions() {
+    void testCreateDynamicTableSourceWithAllOptions() throws Exception {
         Map<String, String> options = createMinimalOptions();
         options.put("port", "9000");
         options.put("schema", "myschema");
@@ -69,6 +72,17 @@ class GaussDBCDCTableSourceFactoryCreateTest {
 
         DynamicTableSource source = createTableSource(options);
         assertThat(source).isInstanceOf(GaussDBCDCTableSource.class);
+        SourceFunctionProvider provider =
+                (SourceFunctionProvider)
+                        ((GaussDBCDCTableSource) source).getScanRuntimeProvider(null);
+        Object function = provider.createSourceFunction();
+        java.lang.reflect.Field chunkSize = function.getClass().getDeclaredField("chunkSize");
+        java.lang.reflect.Field connectTimeout =
+                function.getClass().getDeclaredField("connectTimeoutMs");
+        chunkSize.setAccessible(true);
+        connectTimeout.setAccessible(true);
+        assertThat(chunkSize.get(function)).isEqualTo(5000);
+        assertThat(connectTimeout.get(function)).isEqualTo(60000);
     }
 
     @Test
@@ -125,6 +139,41 @@ class GaussDBCDCTableSourceFactoryCreateTest {
     void testOptionalOptionsCount() {
         GaussDBCDCTableSourceFactory factory = new GaussDBCDCTableSourceFactory();
         assertThat(factory.optionalOptions()).hasSize(17);
+    }
+
+    @Test
+    void testRejectsUnsupportedOutputFormat() {
+        Map<String, String> options = createMinimalOptions();
+        options.put("output.format", "unexpected");
+
+        assertThatThrownBy(() -> createTableSource(options))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("output.format");
+    }
+
+    @Test
+    void testLegacyPluginNameAliasesDecodePlugin() throws Exception {
+        Map<String, String> options = createMinimalOptions();
+        options.put("plugin.name", "legacy_plugin");
+        GaussDBCDCTableSource source = (GaussDBCDCTableSource) createTableSource(options);
+        SourceFunctionProvider provider =
+                (SourceFunctionProvider) source.getScanRuntimeProvider(null);
+        Object function = provider.createSourceFunction();
+        java.lang.reflect.Field field = function.getClass().getDeclaredField("decodePlugin");
+        field.setAccessible(true);
+
+        assertThat(field.get(function)).isEqualTo("legacy_plugin");
+    }
+
+    @Test
+    void testRejectsConflictingPluginOptions() {
+        Map<String, String> options = createMinimalOptions();
+        options.put("plugin.name", "pgoutput");
+        options.put("decode.plugin", "mppdb_decoding");
+
+        assertThatThrownBy(() -> createTableSource(options))
+                .isInstanceOf(ValidationException.class)
+                .hasMessageContaining("Conflicting");
     }
 
     // ---- Helper methods ----

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactoryCreateTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactoryCreateTest.java
@@ -124,7 +124,7 @@ class GaussDBCDCTableSourceFactoryCreateTest {
     @Test
     void testOptionalOptionsCount() {
         GaussDBCDCTableSourceFactory factory = new GaussDBCDCTableSourceFactory();
-        assertThat(factory.optionalOptions()).hasSize(15);
+        assertThat(factory.optionalOptions()).hasSize(16);
     }
 
     // ---- Helper methods ----

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactoryCreateTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactoryCreateTest.java
@@ -124,7 +124,7 @@ class GaussDBCDCTableSourceFactoryCreateTest {
     @Test
     void testOptionalOptionsCount() {
         GaussDBCDCTableSourceFactory factory = new GaussDBCDCTableSourceFactory();
-        assertThat(factory.optionalOptions()).hasSize(16);
+        assertThat(factory.optionalOptions()).hasSize(17);
     }
 
     // ---- Helper methods ----

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactoryTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactoryTest.java
@@ -40,6 +40,6 @@ class GaussDBCDCTableSourceFactoryTest {
     @Test
     void testOptionalOptions() {
         GaussDBCDCTableSourceFactory factory = new GaussDBCDCTableSourceFactory();
-        assertThat(factory.optionalOptions()).hasSize(15);
+        assertThat(factory.optionalOptions()).hasSize(16);
     }
 }

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactoryTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceFactoryTest.java
@@ -40,6 +40,6 @@ class GaussDBCDCTableSourceFactoryTest {
     @Test
     void testOptionalOptions() {
         GaussDBCDCTableSourceFactory factory = new GaussDBCDCTableSourceFactory();
-        assertThat(factory.optionalOptions()).hasSize(16);
+        assertThat(factory.optionalOptions()).hasSize(17);
     }
 }

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceTest.java
@@ -58,6 +58,7 @@ class GaussDBCDCTableSourceTest {
                 "prefer",
                 null,
                 "raw",
+                "debezium",
                 getTestRowType());
     }
 
@@ -113,6 +114,7 @@ class GaussDBCDCTableSourceTest {
                         "prefer",
                         null,
                         "raw",
+                        "debezium",
                         getTestRowType());
 
         assertThat(source.getChangelogMode()).isEqualTo(ChangelogMode.all());

--- a/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceTest.java
+++ b/flink-connector-gaussdb-cdc-2.4.x/src/test/java/org/apache/flink/connector/gaussdbcdc/table/GaussDBCDCTableSourceTest.java
@@ -57,6 +57,7 @@ class GaussDBCDCTableSourceTest {
                 true,
                 "prefer",
                 null,
+                "raw",
                 getTestRowType());
     }
 
@@ -111,6 +112,7 @@ class GaussDBCDCTableSourceTest {
                         false,
                         "prefer",
                         null,
+                        "raw",
                         getTestRowType());
 
         assertThat(source.getChangelogMode()).isEqualTo(ChangelogMode.all());


### PR DESCRIPTION
## 概述

CDC 2.4.x 连接器增强：多表捕获、3 种 JSON 输出格式、WAL 可靠性改进、SQL 注入防护。

## 变更内容

### 1. 多表捕获（#5696603）
- `table-name` 支持正则匹配，可同时捕获多张表
- 同构表（相同 schema）使用 `output.format=raw` 输出 RowData
- 异构表（不同 schema）使用 `output.format=json` 输出单列 JSON

### 2. 三种 JSON 输出格式（#cdf8fff, #7b60865）
- `debezium`（默认）：Debezium 标准 JSON，兼容 Flink CDC `debezium-json` 格式
- `canal`：Alibaba Canal 标准 JSON
- `he`：基于 Canal 的自定义格式（`type`→`optType`，新增 `pkValues`，去掉 `isDdl`/`sqlType`/`mysqlType`）

### 3. WAL 可靠性改进（#58a70c0）
- `RichParallelSourceFunction` + `CheckpointListener`：checkpoint 完成后才确认 WAL LSN，保证 exactly-once
- `prepareSlotForSnapshot()`：快照前创建复制槽，防止快照期间 WAL 丢失
- CSN-based 快照/WAL 去重（3 层 fallback：`pg_export_snapshot_and_csn` → `pg_export_snapshot` + `pg_current_csn` → 禁用 CSN 过滤）
- 事务缓冲：`prepareCommittedWalChanges()` 缓冲 BEGIN→data→COMMIT 序列，仅 COMMIT 后输出
- 延迟 LSN 确认：`sqlUnacknowledgedLsns` 跟踪已读未确认 LSN，checkpoint 完成后推进 slot
- 协调并行快照：MVCC advisory lock 实现 subtask 间一致性快照
- 轮询模式状态序列化：`serializeState()`/`restoreState()` 支持 checkpoint 恢复
- `SqlIdentifierUtils`：所有 SQL 标识符自动引用，防 SQL 注入，兼容 M-compatible 模式
- 复合主键检测：显式报错而非静默使用第一列
- 非数字主键回退：单 subtask 快照，不做并行范围切分
- 重连元数据校验：WAL 重连后检测表结构变化，变化时报错防输出错误数据
- `plugin.name` 废弃为 `decode.plugin` 别名，冲突时抛异常

### 4. README
- 新增 CDC 2.4.x README（多表、JSON 格式、fat/thin JAR 部署说明）
- 修复 CDC 1.17 README（删除误加的 output.format/canal 参数，1.17 源码无此功能）

## 测试

- 单元测试：239 个通过，checkstyle 无需 skip
- Python E2E：35 个断言，9 个场景（快照/INSERT/UPDATE/DELETE/REPLICA IDENTITY FULL/跨批次 DELETE）
- 测试覆盖 3 种 JSON 格式（debezium/canal/he）

## JAR 包

fat/thin JAR 已构建并上传到 fork Release `v3.3.0-1.20-cdc-multi-table`：
- fat: 1.7MB（含 GaussDB JDBC 驱动）
- thin: 100KB（不含驱动）

合并后将更新华为仓 Release `v3.3.2-1.20-normal` 的 CDC 2.4.x 附件。

## 兼容性

- `output.format=raw`（默认）完全向后兼容单表模式
- `table-name` 无正则元字符时走精确匹配（向后兼容）
- `plugin.name` 作为 `decode.plugin` 的废弃别名仍然可用